### PR TITLE
Update to gopkg.in/mgo.v2 repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 juju/txn
 ========
 
-This package wraps labix.org/v2/mgo/txn, providing
+This package wraps gopkg.in/mgo.v2/txn, providing
 convenience functions and interfaces for common
 transaction execution patterns, and also providing
 test hook points.

--- a/txn.go
+++ b/txn.go
@@ -16,8 +16,8 @@ import (
 	stderrors "errors"
 
 	"github.com/juju/loggo"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/txn"
 )
 
 var logger = loggo.GetLogger("juju.txn")

--- a/txn_test.go
+++ b/txn_test.go
@@ -5,9 +5,9 @@ package txn_test
 
 import (
 	"github.com/juju/testing"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
-	"labix.org/v2/mgo/txn"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
 	gc "launchpad.net/gocheck"
 
 	jujutxn "github.com/juju/txn"


### PR DESCRIPTION
labix.org/v2/mgo is no longer maintained.
