### PR TITLE
remove dependency on juju/juju

### DIFF
--- a/package_test.go
+++ b/package_test.go
@@ -6,9 +6,9 @@ package txn_test
 import (
 	stdtesting "testing"
 
-	"github.com/juju/juju/testing"
+	"github.com/juju/testing"
 )
 
 func Test(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
+	testing.MgoTestPackage(t, nil)
 }


### PR DESCRIPTION
The dependency is unnecessary and causes problems with external packages that depend on juju/txn.