### PR TITLE
Added functionality for pruning mgo/txn's transactions collection

### DIFF
--- a/prune.go
+++ b/prune.go
@@ -1,0 +1,129 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package txn
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+// Transaction states copied From mgo/txn.
+const (
+	taborted = 5 // Pre-conditions failed, nothing done
+	tapplied = 6 // All changes applied
+)
+
+// pruneTxns removes applied and aborted entries from the txns
+// collection that are no longer referenced by any document.
+//
+// TODO(mjs) - this knows way too much about mgo/txn's internals and
+// with a bit of luck something like this will one day be part of
+// mgo/txn.
+func pruneTxns(db *mgo.Database, txnsName string) error {
+	present := struct{}{}
+
+	// Load the ids of all completed txns and all collections
+	// referred to by those txns.
+	//
+	// This set could potentially contain many entries, however even
+	// 500,000 entries requires only ~44MB of memory. Given that the
+	// memory hit is short-lived this is probably acceptable.
+	txns := db.C(txnsName)
+	txnIds := make(map[bson.ObjectId]struct{})
+	collNames := make(map[string]struct{})
+
+	var txnDoc struct {
+		Id  bson.ObjectId `bson:"_id"`
+		Ops []txn.Op      `bson:"o"`
+	}
+
+	completed := bson.M{
+		"s": bson.M{"$in": []int{taborted, tapplied}},
+	}
+	iter := txns.Find(completed).Select(bson.M{"_id": 1, "o": 1}).Iter()
+	for iter.Next(&txnDoc) {
+		txnIds[txnDoc.Id] = present
+		for _, op := range txnDoc.Ops {
+			collNames[op.C] = present
+		}
+	}
+	if err := iter.Close(); err != nil {
+		return errors.Annotate(err, "failed to read all known txn ids")
+	}
+
+	// Transactions may also be referenced in the stash.
+	collNames["txns.stash"] = present
+
+	// Now remove the txn ids referenced by all documents in all
+	// txn using collections from the set of known txn ids.
+	//
+	// Working the other way - starting with the set of txns
+	// referenced by documents and then removing any not in that set
+	// from the txns collection - is unsafe as it will result in the
+	// removal of transactions run while pruning executes.
+	//
+	for collName := range collNames {
+		coll := db.C(collName)
+		var tDoc struct {
+			Queue []string `bson:"txn-queue"`
+		}
+		iter := coll.Find(nil).Select(bson.M{"txn-queue": 1}).Iter()
+		for iter.Next(&tDoc) {
+			for _, token := range tDoc.Queue {
+				delete(txnIds, txnTokenToId(token))
+			}
+		}
+		if err := iter.Close(); err != nil {
+			return errors.Annotatef(err, "failed to read all documents for collection %q", collName)
+		}
+	}
+
+	// Remove the unreferenced transactions.
+	err := bulkRemoveTxns(txns, txnIds)
+	return errors.Trace(err)
+}
+
+func txnTokenToId(token string) bson.ObjectId {
+	// mgo/txn transaction tokens are the 24 character txn id
+	// followed by "_<nonce>"
+	return bson.ObjectIdHex(token[:24])
+}
+
+// bulkRemoveTxns removes transaction documents in chunks. It should
+// be significantly more efficient than removing one document per
+// remove query while also not trigger query document size limits.
+func bulkRemoveTxns(txns *mgo.Collection, txnIds map[bson.ObjectId]struct{}) error {
+	removeTxns := func(ids []bson.ObjectId) error {
+		_, err := txns.RemoveAll(bson.M{"_id": bson.M{"$in": ids}})
+		switch err {
+		case nil, mgo.ErrNotFound:
+			// It's OK for txns to no longer exist. Another process
+			// may have concurrently pruned them.
+			return nil
+		default:
+			return errors.Annotatef(err, "failed to prune transactions")
+		}
+	}
+
+	const chunkMax = 1024
+	chunk := make([]bson.ObjectId, 0, chunkMax)
+	for txnId := range txnIds {
+		chunk = append(chunk, txnId)
+		if len(chunk) == chunkMax {
+			if err := removeTxns(chunk); err != nil {
+				return errors.Trace(err)
+			}
+			chunk = chunk[:0] // Avoid reallocation.
+		}
+	}
+	if len(chunk) > 0 {
+		if err := removeTxns(chunk); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	return nil
+}

--- a/prune_test.go
+++ b/prune_test.go
@@ -1,0 +1,334 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package txn_test
+
+import (
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+
+	jujutxn "github.com/juju/txn"
+)
+
+type PruneSuite struct {
+	jujutesting.MgoSuite
+	db     *mgo.Database
+	txns   *mgo.Collection
+	runner *txn.Runner
+}
+
+var _ = gc.Suite(&PruneSuite{})
+
+func (s *PruneSuite) SetUpTest(c *gc.C) {
+	s.MgoSuite.SetUpTest(c)
+	txn.SetChaos(txn.Chaos{})
+
+	s.db = s.Session.DB("prune-test")
+	s.txns = s.db.C("txns")
+	s.runner = txn.NewRunner(s.txns)
+}
+
+func (s *PruneSuite) TearDownSuite(c *gc.C) {
+	txn.SetChaos(txn.Chaos{})
+	s.MgoSuite.TearDownSuite(c)
+}
+
+func (s *PruneSuite) prune(c *gc.C) {
+	r := jujutxn.NewRunner(jujutxn.RunnerParams{
+		Database:                  s.db,
+		TransactionCollectionName: s.txns.Name,
+		ChangeLogName:             s.txns.Name + ".log",
+	})
+	err := r.PruneTransactions()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *PruneSuite) TestSingleCollection(c *gc.C) {
+	// Create some simple transactions, keeping track of the last
+	// transaction id for each document.
+	const numDocs = 5
+	const updatesPerDoc = 3
+
+	lastTxnIds := make([]bson.ObjectId, numDocs)
+	for id := 0; id < numDocs; id++ {
+		s.runTxn(c, txn.Op{
+			C:      "coll",
+			Id:     id,
+			Insert: bson.M{},
+		})
+
+		for txnNum := 0; txnNum < updatesPerDoc; txnNum++ {
+			lastTxnIds[id] = s.runTxn(c, txn.Op{
+				C:      "coll",
+				Id:     id,
+				Update: bson.M{},
+			})
+		}
+	}
+
+	// Ensure that expected number of transactions were created.
+	s.assertCollCount(c, "txns", numDocs+(numDocs*updatesPerDoc))
+
+	s.prune(c)
+
+	// Confirm that only the records for the most recent transactions
+	// for each document were kept.
+	s.assertTxns(c, lastTxnIds...)
+
+	// Run another transaction on each of the docs to ensure mgo/txn
+	// is happy.
+	for id := 0; id < numDocs; id++ {
+		s.runTxn(c, txn.Op{
+			C:      "coll",
+			Id:     id,
+			Update: bson.M{},
+		})
+	}
+}
+
+func (s *PruneSuite) TestMultipleDocumentsInOneTxn(c *gc.C) {
+	// Create two documents each in their own txn.
+	s.runTxn(c, txn.Op{
+		C:      "coll",
+		Id:     0,
+		Insert: bson.M{},
+	})
+	s.runTxn(c, txn.Op{
+		C:      "coll",
+		Id:     1,
+		Insert: bson.M{},
+	})
+
+	// Now update both documents in one transaction.
+	txnId := s.runTxn(c, txn.Op{
+		C:      "coll",
+		Id:     0,
+		Update: bson.M{},
+	}, txn.Op{
+		C:      "coll",
+		Id:     1,
+		Update: bson.M{},
+	})
+
+	s.prune(c)
+
+	// Only the last transaction should be left.
+	s.assertTxns(c, txnId)
+}
+
+func (s *PruneSuite) TestMultipleCollections(c *gc.C) {
+	var lastTxnIds []bson.ObjectId
+
+	// Create a single document.
+	s.runTxn(c, txn.Op{
+		C:      "coll0",
+		Id:     0,
+		Insert: bson.M{},
+	})
+
+	// Update that document and create two more in other collections,
+	// all in one txn. This will be the last txn that touches coll0/0
+	// so it should not be pruned.
+	txnId := s.runTxn(c, txn.Op{
+		C:      "coll0",
+		Id:     0,
+		Update: bson.M{},
+	}, txn.Op{
+		C:      "coll1",
+		Id:     0,
+		Insert: bson.M{},
+	}, txn.Op{
+		C:      "coll2",
+		Id:     0,
+		Insert: bson.M{},
+	})
+	lastTxnIds = append(lastTxnIds, txnId)
+
+	// Update coll1 and coll2 docs together. This will be the last txn
+	// to touch coll1/0 and coll2/0 so it should not be pruned.
+	txnId = s.runTxn(c, txn.Op{
+		C:      "coll1",
+		Id:     0,
+		Update: bson.M{},
+	}, txn.Op{
+		C:      "coll2",
+		Id:     0,
+		Update: bson.M{},
+	})
+	lastTxnIds = append(lastTxnIds, txnId)
+
+	// Insert more documents into coll0 and coll1.
+	txnId = s.runTxn(c, txn.Op{
+		C:      "coll0",
+		Id:     1,
+		Insert: bson.M{},
+	}, txn.Op{
+		C:      "coll1",
+		Id:     1,
+		Insert: bson.M{},
+	})
+	lastTxnIds = append(lastTxnIds, txnId)
+
+	s.prune(c)
+	s.assertTxns(c, lastTxnIds...)
+}
+
+func (s *PruneSuite) TestWithStash(c *gc.C) {
+	// Ensure that txns referenced in the stash are not pruned from
+	// the txns collection.
+
+	// An easy way to get something into the stash is to delete a
+	// document.
+	txnId0 := s.runTxn(c, txn.Op{
+		C:      "coll",
+		Id:     0,
+		Insert: bson.D{},
+	})
+	txnId1 := s.runTxn(c, txn.Op{
+		C:      "coll",
+		Id:     0,
+		Remove: true,
+	})
+	s.assertCollCount(c, "txns.stash", 1)
+
+	s.prune(c)
+	s.assertTxns(c, txnId0, txnId1)
+}
+
+func (s *PruneSuite) TestInProgressInsertNotPruned(c *gc.C) {
+	// Create an incomplete insert transaction.
+	txn.SetChaos(txn.Chaos{
+		KillChance: 1,
+		Breakpoint: "set-applying",
+	})
+	txnId := s.runFailingTxn(c, txn.ErrChaos, txn.Op{
+		C:      "coll",
+		Id:     0,
+		Insert: bson.M{},
+	})
+
+	// There will be in-progress txns and txns.stash entries for the
+	// new document now. Remove the stash entry to simulate the point
+	// in time where the txns doc has been inserted but the txns.stash
+	// doc hasn't yet.
+	err := s.db.C("txns.stash").RemoveId(bson.D{
+		{"c", "coll"},
+		{"id", 0},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.prune(c)
+	s.assertTxns(c, txnId)
+}
+
+func (s *PruneSuite) TestInProgressUpdateNotPruned(c *gc.C) {
+	// Create an insert transaction and then in-progress update
+	// transaction.
+	txnIdInsert := s.runTxn(c, txn.Op{
+		C:      "coll",
+		Id:     0,
+		Insert: bson.M{},
+	})
+
+	txn.SetChaos(txn.Chaos{
+		KillChance: 1,
+		Breakpoint: "set-prepared",
+	})
+	txnIdUpdate := s.runFailingTxn(c, txn.ErrChaos, txn.Op{
+		C:      "coll",
+		Id:     0,
+		Update: bson.M{},
+	})
+
+	// Remove reference to the update transaction from the doc to
+	// simulate the point in time where the txns doc has been created
+	// but it's not referenced from the doc being updated yet.
+	coll := s.db.C("coll")
+	err := coll.UpdateId(0, bson.M{
+		"$pull": bson.M{"txn-queue": bson.M{"$regex": "^" + txnIdUpdate.Hex() + "_*"}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.prune(c)
+	s.assertTxns(c, txnIdInsert, txnIdUpdate)
+}
+
+func (s *PruneSuite) TestAbortedTxnsArePruned(c *gc.C) {
+	// Create an insert transaction, then an aborted transaction
+	// and then a successful transaction, all for same doc.
+	s.runTxn(c, txn.Op{
+		C:      "coll",
+		Id:     0,
+		Insert: bson.M{},
+	})
+	s.runFailingTxn(c, txn.ErrAborted, txn.Op{
+		C:      "coll",
+		Id:     0,
+		Assert: txn.DocMissing, // Aborts because doc is already there.
+	})
+	txnId := s.runTxn(c, txn.Op{
+		C:      "coll",
+		Id:     0,
+		Update: bson.M{},
+	})
+
+	s.prune(c)
+	s.assertTxns(c, txnId)
+}
+
+func (s *PruneSuite) TestManyTxnRemovals(c *gc.C) {
+	// This is mainly to test the chunking of removals.
+	s.runTxn(c, txn.Op{
+		C:      "coll",
+		Id:     0,
+		Insert: bson.M{},
+	})
+	var lastTxnId bson.ObjectId
+	for i := 0; i < 3000; i++ {
+		lastTxnId = s.runTxn(c, txn.Op{
+			C:      "coll",
+			Id:     0,
+			Update: bson.M{},
+		})
+	}
+	s.assertCollCount(c, "txns", 3001)
+
+	s.prune(c)
+	s.assertTxns(c, lastTxnId)
+}
+
+func (s *PruneSuite) runTxn(c *gc.C, ops ...txn.Op) bson.ObjectId {
+	txnId := bson.NewObjectId()
+	err := s.runner.Run(ops, txnId, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	return txnId
+}
+
+func (s *PruneSuite) runFailingTxn(c *gc.C, expectedErr error, ops ...txn.Op) bson.ObjectId {
+	txnId := bson.NewObjectId()
+	err := s.runner.Run(ops, txnId, nil)
+	c.Assert(err, gc.Equals, expectedErr)
+	return txnId
+}
+
+func (s *PruneSuite) assertTxns(c *gc.C, expectedIds ...bson.ObjectId) {
+	var actualIds []bson.ObjectId
+	var txnDoc struct {
+		Id bson.ObjectId `bson:"_id"`
+	}
+	iter := s.txns.Find(nil).Select(bson.M{"_id": 1}).Iter()
+	for iter.Next(&txnDoc) {
+		actualIds = append(actualIds, txnDoc.Id)
+	}
+	c.Assert(actualIds, jc.SameContents, expectedIds)
+}
+
+func (s *PruneSuite) assertCollCount(c *gc.C, collName string, expectedCount int) {
+	count, err := s.db.C(collName).Count()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(count, gc.Equals, expectedCount)
+}

--- a/txn.go
+++ b/txn.go
@@ -63,6 +63,11 @@ type Runner interface {
 
 	// ResumeTransactions resumes all pending transactions.
 	ResumeTransactions() error
+
+	// PruneTransactions removes data for completed transactions from
+	// mgo/txn's transaction collection. It is intended to be called
+	// periodically.
+	PruneTransactions() error
 }
 
 type transactionRunner struct {
@@ -173,6 +178,11 @@ func (tr *transactionRunner) RunTransaction(ops []txn.Op) error {
 func (tr *transactionRunner) ResumeTransactions() error {
 	runner := tr.newRunner()
 	return runner.ResumeAll()
+}
+
+// PruneTransactions is defined on Runner.
+func (tr *transactionRunner) PruneTransactions() error {
+	return pruneTxns(tr.db, tr.transactionCollectionName)
 }
 
 // TestHook holds a pair of functions to be called before and after a


### PR DESCRIPTION
If left alone, the collection used by mgo/txn to coordinate and track client-side transactions will grow without bound.

This change adds a PruneTransactions method to the Runner interface. This can be called at any time to remove mgo/txn's documents for applied and aborted transactions. It is intended to be called periodically.

(Review request: http://reviews.vapour.ws/r/1705/)