### PR TITLE
Record historical pruning stats

### DIFF
--- a/txn.go
+++ b/txn.go
@@ -188,23 +188,7 @@ func (tr *transactionRunner) ResumeTransactions() error {
 
 // MaybePruneTransactions is defined on Runner.
 func (tr *transactionRunner) MaybePruneTransactions(pruneFactor float32) error {
-	txns := tr.db.C(tr.transactionCollectionName)
-	txnsPrune := tr.db.C(txnsPruneC(tr.transactionCollectionName))
-
-	required, err := isPruningRequired(txnsPrune, txns, pruneFactor)
-	if err != nil {
-		return err
-	}
-
-	if required {
-		err := pruneTxns(tr.db, txns)
-		if err != nil {
-			return err
-		}
-		return writePruneTxnsCount(txnsPrune, txns)
-	}
-
-	return nil
+	return maybePrune(tr.db, tr.transactionCollectionName, pruneFactor)
 }
 
 // TestHook holds a pair of functions to be called before and after a


### PR DESCRIPTION
Instead of just recording details of the last pruning run in the txns.prune collection, details for all pruning runs are now kept. More stats are kept now to allow analysis of pruning performance. For quick access, a pointer document is used to track the most recent result (required for regular pruning checks).

(Review request: http://reviews.vapour.ws/r/1763/)