### PR TITLE
Fix prune.* licence header.

### DIFF
--- a/prune.go
+++ b/prune.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package txn
 

--- a/prune_test.go
+++ b/prune_test.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package txn_test
 


### PR DESCRIPTION
The prune.* files were ascribed the AGPLv3 licence by mistake. This project is LGPLv3 for original work.

This fixes an issue raised by Ubuntu regarding 1.22.5. They will accept the package if we show that this issue is fixed in master.
    https://bugs.launchpad.net/juju-core/+bug/1463455

(Review request: http://reviews.vapour.ws/r/1898/)