### PR TITLE
Cleanup all collections

### DIFF
--- a/cleaner.go
+++ b/cleaner.go
@@ -1,0 +1,384 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package txn
+
+import (
+	"fmt"
+	"time"
+
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// CollectionConfig is the definition of what we will be cleaning up.
+type CollectionConfig struct {
+	// Txns is the collection holding the Transaction documents.
+	Txns *mgo.Collection
+
+	// Source is the mongo collection holding documents created and managed
+	// by transactions.
+	Source *mgo.Collection
+
+	// NumBatchTokens is the number of tokens that we will cache before
+	// doing a query to find out whether their referenced transactions are
+	// completed. It is useful to have a number in the hundreds so that we
+	// efficiently query the mongo transaction database.
+	NumBatchTokens int
+
+	// MaxRemoveQueue is the maximum number of document ids that we will
+	// hold on to in memory before we go back to the database to purge those
+	// documents. This only affects StashCollectionCleaner, as the generic
+	// cleaner never removes documents.
+	MaxRemoveQueue int
+
+	// LogInterval defines how often we will show progress
+	LogInterval time.Duration
+}
+
+// CollectionStats tracks various counters that signal how the collector operated.
+type CollectionStats struct {
+
+	// DocCount is the total number of documents evaluated.
+	DocCount int
+
+	// TokenCount is the total number of transaction tokens that were
+	// referenced by the documents.
+	TokenCount int
+
+	// CompletedTokenCount is the number of unique tokens that referenced
+	// completed transactions.
+	CompletedTokenCount int
+
+	// CompletedTxnCount is the number of completed transactions that we
+	// looked up.
+	CompletedTxnCount int
+
+	// UpdatedDocCount is the number of documents we modified without
+	// removing them
+	UpdatedDocCount int
+
+	// PulledCount is the number of tokens that were removed from documents.
+	PulledTokenCount int
+
+	// RemovedCount represents the number of txns.stash documents that we
+	// decided to remove entirely.
+	RemovedCount int
+}
+
+// txnDocument represents the fields we care about for objects that participate
+// in transactions. They must all have an _id so we can find them again, and a
+// txn-queue so that they can refer to transactions. (we don't need the
+// txn-revno and other fields at this point.)
+type txnDocument struct {
+	// Id is the _id field of the document. We use a bson.Raw so that we
+	// don't enforce the structure, we just need to pass it back in.
+	// interface{} causes bson to Unmarshall string/int correctly but
+	// creates a bson.M for objects which loses ordering. bson.D causes
+	// objects to deserialize correctly but fails to deserialize a simple
+	// int or string.
+	Id    bson.Raw `bson:"_id"`
+	Queue []string `bson:"txn-queue"`
+}
+
+// collectionCleaner represents the state while we process a collection for
+// transaction ids that no longer need to be referenced because they refer to
+// transactions that have been completed.
+type collectionCleaner struct {
+	config         CollectionConfig
+	docIdsToRemove []interface{}
+	docsToProcess  []txnDocument
+	tokensToLookup []string
+	stats          CollectionStats
+	// removeIfEmpty will remove documents that have all references removed.
+	// This should only be set True for txns.stash
+	removeIfEmpty bool
+}
+
+func (stats CollectionStats) Details() string {
+	return fmt.Sprintf("processed %d documents, removed %d, updated %d (%d tokens)\n"+
+		"checked %d tokens (%d completed unique) across %d completed transactions",
+		stats.DocCount, stats.RemovedCount, stats.UpdatedDocCount, stats.PulledTokenCount,
+		stats.TokenCount, stats.CompletedTokenCount, stats.CompletedTxnCount)
+}
+
+// NewCollectionCleaner creates an object that can remove transaction tokens
+// from document queues when the transactions have been marked as completed.
+func NewCollectionCleaner(config CollectionConfig) *collectionCleaner {
+	if config.NumBatchTokens == 0 {
+		config.NumBatchTokens = queueBatchSize
+	}
+	if config.MaxRemoveQueue == 0 {
+		config.MaxRemoveQueue = maxMemoryTokens
+	}
+	if config.LogInterval == 0 {
+		config.LogInterval = logInterval
+	}
+	return &collectionCleaner{
+		config:         config,
+		docIdsToRemove: make([]interface{}, 0),
+		docsToProcess:  make([]txnDocument, 0),
+		tokensToLookup: make([]string, 0),
+		removeIfEmpty:  false,
+	}
+}
+
+// NewStashCleaner returns an object suitable for cleaning up the txns.stash collection.
+// It is different because when we find all references from a document have been
+// removed, we can remove the document.
+func NewStashCleaner(config CollectionConfig) *collectionCleaner {
+	return &collectionCleaner{
+		config:         config,
+		docIdsToRemove: make([]interface{}, 0),
+		docsToProcess:  make([]txnDocument, 0),
+		tokensToLookup: make([]string, 0),
+		removeIfEmpty:  true,
+	}
+}
+
+// includeDoc queues this doc to be processed. It returns 'true' if the docs
+// should be processed.
+func (cleaner *collectionCleaner) includeDoc(doc txnDocument) error {
+	cleaner.stats.DocCount++
+	cleaner.docsToProcess = append(cleaner.docsToProcess, doc)
+	for _, token := range doc.Queue {
+		cleaner.tokensToLookup = append(cleaner.tokensToLookup, token)
+	}
+	return nil
+}
+
+// findCompletedTokens looks at the list of tokens and finds what txns are
+// referenced as completed, and then returns the set of tokens that are completed.
+func (cleaner *collectionCleaner) findCompletedTokens() (map[string]bool, error) {
+	objectIds := make([]bson.ObjectId, 0, len(cleaner.tokensToLookup))
+
+	// The nonce is generated during preparing, and if 2 flushers race,
+	// only one nonce makes it into the final transaction. However, other
+	// nonces can also be considered 'completed'. (afaict, they are ignored,
+	// thus won't be applied and can be considered completed.)
+	for _, token := range cleaner.tokensToLookup {
+		objId := txnTokenToId(token)
+		objectIds = append(objectIds, objId)
+	}
+	query := cleaner.config.Txns.Find(
+		bson.M{"_id": bson.M{"$in": objectIds},
+			"s": bson.M{"$in": []int{tapplied, taborted}}})
+	query = query.Select(bson.M{"_id": 1})
+	iter := query.Iter()
+	var txnDoc struct {
+		Id bson.ObjectId `bson:"_id"`
+	}
+	foundIdHex := make(map[string]bool, len(objectIds))
+	for iter.Next(&txnDoc) {
+		foundIdHex[txnDoc.Id.Hex()] = true
+	}
+	if err := iter.Close(); err != nil {
+		if err != mgo.ErrNotFound {
+			// Not found is ok, the transactions may not be complete
+			return nil, err
+		}
+	}
+	result := make(map[string]bool, len(foundIdHex))
+	for _, token := range cleaner.tokensToLookup {
+		objIdHex := txnTokenToId(token).Hex()
+		if foundIdHex[objIdHex] {
+			result[token] = true
+		}
+	}
+	cleaner.stats.TokenCount += len(cleaner.tokensToLookup)
+	cleaner.stats.CompletedTokenCount += len(result)
+	cleaner.stats.CompletedTxnCount += len(foundIdHex)
+	return result, nil
+}
+
+// findPullableTokens checks to see what transaction tokens should be removed
+// from this document.
+func (*collectionCleaner) findPullableTokens(queue []string, completedTokens map[string]bool) []string {
+	toRemove := make([]string, 0, len(queue))
+	for _, token := range queue {
+		if completedTokens[token] {
+			// We found the completed token, thus it can be removed
+			toRemove = append(toRemove, token)
+		}
+	}
+	return toRemove
+}
+
+// processStashDocs operates on the queue of documents that we have pending
+// to be processed.
+func (cleaner *collectionCleaner) processStashDocs() error {
+	if len(cleaner.docsToProcess) == 0 {
+		return nil
+	}
+	completedTokens, err := cleaner.findCompletedTokens()
+	if err != nil {
+		return fmt.Errorf("error looking up completed transactions: %v", err)
+	}
+	pullChunk := cleaner.config.Source.Bulk()
+	pullChunk.Unordered()
+	pullCount := 0
+	pullsToApply := 0
+	flushPulls := func() error {
+		result, err := pullChunk.Run()
+		if err != nil {
+			if err != mgo.ErrNotFound {
+				// not found is odd, but not considered fatal,
+				// all others are
+				return fmt.Errorf("error while updating documents: %v", err)
+			}
+		}
+		cleaner.stats.UpdatedDocCount += result.Matched
+		cleaner.stats.PulledTokenCount += pullsToApply
+		pullChunk = cleaner.config.Source.Bulk()
+		pullChunk.Unordered()
+		pullCount = 0
+		pullsToApply = 0
+		return nil
+	}
+	for _, doc := range cleaner.docsToProcess {
+		toPull := cleaner.findPullableTokens(doc.Queue, completedTokens)
+		if cleaner.removeIfEmpty && len(toPull) == len(doc.Queue) {
+			// this document can just be removed from the stash
+			cleaner.docIdsToRemove = append(cleaner.docIdsToRemove, doc.Id)
+		} else if len(toPull) > 0 {
+			// Note: (jam 2017-04-04) An observation, if it is legal
+			// to pull a token from one document, it is legal to
+			// pull it from all other documents. We could do
+			// bulk operations by using the union of all
+			// document ids and the union of all tokens to pull.
+			pullsToApply += len(toPull)
+			pull := bson.M{"$pullAll": bson.M{"txn-queue": toPull}}
+			pullChunk.Update(bson.M{"_id": doc.Id}, pull)
+			pullCount += 1
+			if pullCount >= maxBulkOps {
+				if err := flushPulls(); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	if err := flushPulls(); err != nil {
+		return err
+	}
+	// We've handled these tokens and documents
+	cleaner.tokensToLookup = cleaner.tokensToLookup[:0]
+	cleaner.docsToProcess = cleaner.docsToProcess[:0]
+	return nil
+}
+
+// checkFlush checks if it is worth processing documents now, and returns
+// 'true' if we actually processed them and caused a removal pass to run.
+func (cleaner *collectionCleaner) checkFlush() (bool, error) {
+	if len(cleaner.tokensToLookup) <= cleaner.config.NumBatchTokens {
+		return false, nil
+	}
+	if err := cleaner.processStashDocs(); err != nil {
+		return false, err
+	}
+	if len(cleaner.docIdsToRemove) > cleaner.config.MaxRemoveQueue {
+		return false, nil
+	}
+	if err := cleaner.flushRemoveQueue(); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
+// flushRemoveQueue ensures that all pending removals are flushed to the database.
+func (cleaner *collectionCleaner) flushRemoveQueue() error {
+	if len(cleaner.docIdsToRemove) == 0 {
+		return nil
+	}
+	remover := newBulkRemover(cleaner.config.Source)
+	for _, docId := range cleaner.docIdsToRemove {
+		if err := remover.remove(docId); err != nil {
+			return fmt.Errorf("failed while removing document %v from %q",
+				docId, cleaner.config.Source.Name)
+		}
+	}
+	if err := remover.flush(); err != nil {
+		return fmt.Errorf("failed while removing documents from %q",
+			cleaner.config.Source.Name)
+	}
+	cleaner.stats.RemovedCount += remover.removed
+	logger.Debugf("flushing %d documents removed %d (%d total)",
+		len(cleaner.docIdsToRemove), remover.removed, cleaner.stats.RemovedCount)
+	cleaner.docIdsToRemove = cleaner.docIdsToRemove[:0]
+	return nil
+}
+
+// Cleanup iterates the collection and ensures that all documents no longer
+// reference completed transactions.
+func (cleaner *collectionCleaner) Cleanup() error {
+	logger.Debugf("cleaning up completed references from %q",
+		cleaner.config.Source.Name)
+	startCount, _ := cleaner.config.Source.Count()
+	t := newSimpleTimer(cleaner.config.LogInterval)
+	// If we delete documents while we iterate, it can cause the iterator to
+	// miss documents. So we do multiple passes on the database to make sure
+	// we catch everything.
+	var doc txnDocument
+	for iterCount := 0; iterCount < maxIterCount; iterCount++ {
+		removedWhileIterating := false
+		// We only need to consider documents that have at least 1
+		// entry in their txn-queue
+		filter := bson.M{"txn-queue.0": bson.M{"$exists": 1}}
+		if cleaner.removeIfEmpty {
+			// Unless we are going to remove empty documents,
+			// then we need to handle ones that have a queue.
+			filter = bson.M{"txn-queue": bson.M{"$exists": 1}}
+		}
+		query := cleaner.config.Source.Find(filter)
+		query.Batch(maxBatchDocs)
+		iter := query.Iter()
+		for iter.Next(&doc) {
+			if err := cleaner.includeDoc(doc); err != nil {
+				return err
+			}
+			if t.isAfter() {
+				logger.Debugf("processed %d/%d docs from %q (removed %d)",
+					cleaner.stats.DocCount, startCount,
+					cleaner.config.Source.Name, cleaner.stats.RemovedCount)
+			}
+			didFlush, err := cleaner.checkFlush()
+			if err != nil {
+				return err
+			}
+			if didFlush {
+				removedWhileIterating = true
+			}
+		}
+		if err := cleaner.processStashDocs(); err != nil {
+			return err
+		}
+		if err := cleaner.flushRemoveQueue(); err != nil {
+			return err
+		}
+		if err := iter.Close(); err != nil {
+			return fmt.Errorf("error while iterating %q: %v",
+				cleaner.config.Source.Name, err)
+		}
+		if !removedWhileIterating {
+			break
+		}
+	}
+	logger.Debugf("%s", cleaner.stats.Details())
+	if cleaner.removeIfEmpty {
+		finalCount, _ := cleaner.config.Source.Count()
+		logger.Debugf("%s has %d documents left",
+			cleaner.config.Source.Name, finalCount)
+	}
+	return nil
+}
+
+// CleanupStash goes through the txns.stash and removes documents that are no longer needed.
+func CleanupStash(db *mgo.Database, txns, txnsStash *mgo.Collection) error {
+	cleaner := NewStashCleaner(CollectionConfig{
+		Txns:           txns,
+		Source:         txnsStash,
+		NumBatchTokens: queueBatchSize,
+		MaxRemoveQueue: maxMemoryTokens,
+		LogInterval:    logInterval,
+	})
+	return cleaner.Cleanup()
+}

--- a/prune_test.go
+++ b/prune_test.go
@@ -59,7 +59,11 @@ func (s *PruneSuite) maybePrune(c *gc.C, pruneFactor float32) {
 		TransactionCollectionName: s.txns.Name,
 		ChangeLogName:             s.txns.Name + ".log",
 	})
-	err := r.MaybePruneTransactions(pruneFactor)
+	err := r.MaybePruneTransactions(jujutxn.PruneOptions{
+		PruneFactor:        pruneFactor,
+		MinNewTransactions: 1,
+		MaxNewTransactions: 1000,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -69,7 +73,6 @@ func (s *PruneSuite) TestSingleCollection(c *gc.C) {
 	const numDocs = 5
 	const updatesPerDoc = 3
 
-	lastTxnIds := make([]bson.ObjectId, numDocs)
 	for id := 0; id < numDocs; id++ {
 		s.runTxn(c, txn.Op{
 			C:      "coll",
@@ -77,13 +80,22 @@ func (s *PruneSuite) TestSingleCollection(c *gc.C) {
 			Insert: bson.M{},
 		})
 
-		for txnNum := 0; txnNum < updatesPerDoc; txnNum++ {
-			lastTxnIds[id] = s.runTxn(c, txn.Op{
+		for txnNum := 0; txnNum < updatesPerDoc-1; txnNum++ {
+			s.runTxn(c, txn.Op{
 				C:      "coll",
 				Id:     id,
 				Update: bson.M{},
 			})
 		}
+	}
+	// Now create a transaction for each document that is interrupted
+	lastTxnIds := make([]bson.ObjectId, numDocs)
+	for id := 0; id < numDocs; id++ {
+		lastTxnIds[id] = s.runInterruptedTxn(c, txn.Op{
+			C:      "coll",
+			Id:     id,
+			Insert: bson.M{},
+		})
 	}
 
 	// Ensure that expected number of transactions were created.
@@ -94,6 +106,10 @@ func (s *PruneSuite) TestSingleCollection(c *gc.C) {
 	// Confirm that only the records for the most recent transactions
 	// for each document were kept.
 	s.assertTxns(c, lastTxnIds...)
+
+	for id := 0; id < numDocs; id++ {
+		s.assertDocQueue(c, "coll", id, lastTxnIds[id])
+	}
 
 	// Run another transaction on each of the docs to ensure mgo/txn
 	// is happy.
@@ -120,7 +136,7 @@ func (s *PruneSuite) TestMultipleDocumentsInOneTxn(c *gc.C) {
 	})
 
 	// Now update both documents in one transaction.
-	txnId := s.runTxn(c, txn.Op{
+	txnId := s.runInterruptedTxn(c, txn.Op{
 		C:      "coll",
 		Id:     0,
 		Update: bson.M{},
@@ -134,6 +150,8 @@ func (s *PruneSuite) TestMultipleDocumentsInOneTxn(c *gc.C) {
 
 	// Only the last transaction should be left.
 	s.assertTxns(c, txnId)
+	s.assertDocQueue(c, "coll", 0, txnId)
+	s.assertDocQueue(c, "coll", 1, txnId)
 }
 
 func (s *PruneSuite) TestMultipleCollections(c *gc.C) {
@@ -147,9 +165,8 @@ func (s *PruneSuite) TestMultipleCollections(c *gc.C) {
 	})
 
 	// Update that document and create two more in other collections,
-	// all in one txn. This will be the last txn that touches coll0/0
-	// so it should not be pruned.
-	txnId := s.runTxn(c, txn.Op{
+	// all in one txn. The reference will be removed, so this will be pruned.
+	s.runTxn(c, txn.Op{
 		C:      "coll0",
 		Id:     0,
 		Update: bson.M{},
@@ -162,11 +179,10 @@ func (s *PruneSuite) TestMultipleCollections(c *gc.C) {
 		Id:     0,
 		Insert: bson.M{},
 	})
-	lastTxnIds = append(lastTxnIds, txnId)
 
-	// Update coll1 and coll2 docs together. This will be the last txn
-	// to touch coll1/0 and coll2/0 so it should not be pruned.
-	txnId = s.runTxn(c, txn.Op{
+	// Update coll1 and coll2 docs together. This will be touching
+	// coll1/0 and coll2/0 so it should not be pruned.
+	txnId1 := s.runInterruptedTxn(c, txn.Op{
 		C:      "coll1",
 		Id:     0,
 		Update: bson.M{},
@@ -175,10 +191,10 @@ func (s *PruneSuite) TestMultipleCollections(c *gc.C) {
 		Id:     0,
 		Update: bson.M{},
 	})
-	lastTxnIds = append(lastTxnIds, txnId)
+	lastTxnIds = append(lastTxnIds, txnId1)
 
 	// Insert more documents into coll0 and coll1.
-	txnId = s.runTxn(c, txn.Op{
+	txnId2 := s.runInterruptedTxn(c, txn.Op{
 		C:      "coll0",
 		Id:     1,
 		Insert: bson.M{},
@@ -187,22 +203,34 @@ func (s *PruneSuite) TestMultipleCollections(c *gc.C) {
 		Id:     1,
 		Insert: bson.M{},
 	})
-	lastTxnIds = append(lastTxnIds, txnId)
 
+	// Modifies existing documents that have pending transactions
+	txnId3 := s.runInterruptedTxn(c, txn.Op{
+		C:      "coll1",
+		Id:     0,
+		Update: bson.M{},
+	}, txn.Op{
+		C:      "coll0",
+		Id:     1,
+		Update: bson.M{},
+	})
 	s.maybePrune(c, 1)
-	s.assertTxns(c, lastTxnIds...)
+	s.assertTxns(c, txnId1, txnId2, txnId3)
+	// check that the transactions have been removed from documents
+	s.assertDocQueue(c, "coll1", 0, txnId1, txnId3)
+	s.assertDocQueue(c, "coll2", 0, txnId1)
+	// These documents are still in the stash because their insert got
+	// interrupted
+	s.assertStashDocQueue(c, "coll0", 1, txnId2, txnId3)
+	s.assertStashDocQueue(c, "coll1", 1, txnId2)
 }
 
 func (s *PruneSuite) TestWithStashReference(c *gc.C) {
 	// Ensure that txns referenced in the stash are not pruned from
 	// the txns collection.
 
-	// An easy way to get something into the stash is to create a document, but have the transaction fail
-	txn.SetChaos(txn.Chaos{
-		KillChance: 1,
-		Breakpoint: "set-applying",
-	})
-	txnId := s.runFailingTxn(c, txn.ErrChaos, txn.Op{
+	// An easy way to get something into the stash is to interrupt creating a document
+	txnId := s.runInterruptedTxn(c, txn.Op{
 		C:      "coll",
 		Id:     0,
 		Insert: bson.M{},
@@ -211,42 +239,43 @@ func (s *PruneSuite) TestWithStashReference(c *gc.C) {
 
 	s.maybePrune(c, 1)
 	s.assertTxns(c, txnId)
+	// And the doc still refers to the transaction that is creating it
+	s.assertStashDocQueue(c, "coll", 0, txnId)
 }
 
 func (s *PruneSuite) TestStashCleanedUp(c *gc.C) {
-	// Test that items that were created and removed have been put into the stash, but now we're able to clean them
-	// up if all of their transactions have been marked completed.
-	txnId := s.runTxn(c, txn.Op{
+	// Test that items that were created and removed have been put into the
+	// stash, but now we're able to clean them up if all of their
+	// transactions have been marked completed.
+	add0Id := s.runTxn(c, txn.Op{
 		C:      "coll",
 		Id:     0,
 		Insert: bson.M{},
 	})
-	addId := s.runTxn(c, txn.Op{
+	add1Id := s.runTxn(c, txn.Op{
 		C:      "coll",
 		Id:     1,
 		Insert: bson.M{},
 	})
-	removeId := s.runTxn(c, txn.Op{
+	remove1Id := s.runTxn(c, txn.Op{
 		C:      "coll",
 		Id:     1,
 		Remove: true,
 	})
-	s.assertTxns(c, txnId, addId, removeId)
+	s.assertTxns(c, add0Id, add1Id, remove1Id)
 	s.assertCollCount(c, "txns.stash", 1)
 	s.maybePrune(c, 1.0)
 	s.assertCollCount(c, "txns.stash", 0)
 	// The document 1 should be removed from the stash, no longer referencing either the
 	// insert or the remove which allows us to remove the transactions
-	s.assertTxns(c, txnId)
+	s.assertTxns(c)
+	s.assertDocQueue(c, "coll", 0)
+	// we can't assert the queue on id=1 because the doc no longer exists.
 }
 
 func (s *PruneSuite) TestInProgressInsertNotPruned(c *gc.C) {
 	// Create an incomplete insert transaction.
-	txn.SetChaos(txn.Chaos{
-		KillChance: 1,
-		Breakpoint: "set-applying",
-	})
-	txnId := s.runFailingTxn(c, txn.ErrChaos, txn.Op{
+	txnId := s.runInterruptedTxn(c, txn.Op{
 		C:      "coll",
 		Id:     0,
 		Insert: bson.M{},
@@ -269,7 +298,7 @@ func (s *PruneSuite) TestInProgressInsertNotPruned(c *gc.C) {
 func (s *PruneSuite) TestInProgressUpdateNotPruned(c *gc.C) {
 	// Create an insert transaction and then in-progress update
 	// transaction.
-	txnIdInsert := s.runTxn(c, txn.Op{
+	s.runTxn(c, txn.Op{
 		C:      "coll",
 		Id:     0,
 		Insert: bson.M{},
@@ -295,7 +324,27 @@ func (s *PruneSuite) TestInProgressUpdateNotPruned(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.maybePrune(c, 1)
-	s.assertTxns(c, txnIdInsert, txnIdUpdate)
+	s.assertTxns(c, txnIdUpdate)
+}
+
+func (s *PruneSuite) TestInProgressUpdateNotCleaned(c *gc.C) {
+	// Create an insert transaction and then in-progress update
+	// transaction.
+	s.runTxn(c, txn.Op{
+		C:      "coll",
+		Id:     0,
+		Insert: bson.M{},
+	})
+
+	txnIdUpdate := s.runInterruptedTxn(c, txn.Op{
+		C:      "coll",
+		Id:     0,
+		Update: bson.M{},
+	})
+
+	s.maybePrune(c, 1)
+	s.assertTxns(c, txnIdUpdate)
+	s.assertDocQueue(c, "coll", 0, txnIdUpdate)
 }
 
 func (s *PruneSuite) TestAbortedTxnsArePruned(c *gc.C) {
@@ -310,8 +359,9 @@ func (s *PruneSuite) TestAbortedTxnsArePruned(c *gc.C) {
 		C:      "coll",
 		Id:     0,
 		Assert: txn.DocMissing, // Aborts because doc is already there.
+		Insert: bson.M{},
 	})
-	txnId := s.runTxn(c, txn.Op{
+	txnId := s.runInterruptedTxn(c, txn.Op{
 		C:      "coll",
 		Id:     0,
 		Update: bson.M{},
@@ -319,6 +369,7 @@ func (s *PruneSuite) TestAbortedTxnsArePruned(c *gc.C) {
 
 	s.maybePrune(c, 1)
 	s.assertTxns(c, txnId)
+	s.assertDocQueue(c, "coll", 0, txnId)
 }
 
 func (s *PruneSuite) TestManyTxnRemovals(c *gc.C) {
@@ -328,9 +379,8 @@ func (s *PruneSuite) TestManyTxnRemovals(c *gc.C) {
 		Id:     0,
 		Insert: bson.M{},
 	})
-	var lastTxnId bson.ObjectId
 	for i := 0; i < 3000; i++ {
-		lastTxnId = s.runTxn(c, txn.Op{
+		s.runTxn(c, txn.Op{
 			C:      "coll",
 			Id:     0,
 			Update: bson.M{},
@@ -339,7 +389,8 @@ func (s *PruneSuite) TestManyTxnRemovals(c *gc.C) {
 	s.assertCollCount(c, "txns", 3001)
 
 	s.maybePrune(c, 1)
-	s.assertTxns(c, lastTxnId)
+	s.assertTxns(c)
+	s.assertDocQueue(c, "coll", 0)
 }
 
 func (s *PruneSuite) TestFirstRun(c *gc.C) {
@@ -350,8 +401,8 @@ func (s *PruneSuite) TestFirstRun(c *gc.C) {
 
 	s.maybePrune(c, 2.0)
 
-	s.assertCollCount(c, "txns", 1)
-	s.assertLastPruneStats(c, 10, 1)
+	s.assertCollCount(c, "txns", 0)
+	s.assertLastPruneStats(c, 10, 0)
 	s.assertPruneStatCount(c, 1)
 }
 
@@ -366,8 +417,8 @@ func (s *PruneSuite) TestPruningRequired(c *gc.C) {
 
 	s.maybePrune(c, 2.0)
 
-	s.assertCollCount(c, "txns", 2)
-	s.assertLastPruneStats(c, 10, 2)
+	s.assertCollCount(c, "txns", 0)
+	s.assertLastPruneStats(c, 10, 0)
 	s.assertPruneStatCount(c, 2)
 }
 
@@ -394,19 +445,19 @@ func (s *PruneSuite) TestPruningStatsHistory(c *gc.C) {
 	s.makeTxnsForNewDoc(c, 5)
 
 	s.maybePrune(c, 2.0)
-	s.assertLastPruneStats(c, 5, 1)
+	s.assertLastPruneStats(c, 5, 0)
 	s.assertPruneStatCount(c, 2)
 
 	s.makeTxnsForNewDoc(c, 11)
 
 	s.maybePrune(c, 2.0)
-	s.assertLastPruneStats(c, 12, 2)
+	s.assertLastPruneStats(c, 11, 0)
 	s.assertPruneStatCount(c, 3)
 
 	s.makeTxnsForNewDoc(c, 5)
 
 	s.maybePrune(c, 2.0)
-	s.assertLastPruneStats(c, 7, 3)
+	s.assertLastPruneStats(c, 5, 0)
 	s.assertPruneStatCount(c, 4)
 }
 
@@ -463,6 +514,17 @@ func (s *PruneSuite) runFailingTxn(c *gc.C, expectedErr error, ops ...txn.Op) bs
 	return txnId
 }
 
+// runInterruptedTxn starts a transaction, but interrupts it just before it gets applied.
+func (s *PruneSuite) runInterruptedTxn(c *gc.C, ops ...txn.Op) bson.ObjectId {
+	txn.SetChaos(txn.Chaos{
+		KillChance: 1,
+		Breakpoint: "set-applying",
+	})
+	txnId := s.runFailingTxn(c, txn.ErrChaos, ops...)
+	txn.SetChaos(txn.Chaos{})
+	return txnId
+}
+
 func (s *PruneSuite) assertTxns(c *gc.C, expectedIds ...bson.ObjectId) {
 	var actualIds []bson.ObjectId
 	var txnDoc struct {
@@ -473,6 +535,32 @@ func (s *PruneSuite) assertTxns(c *gc.C, expectedIds ...bson.ObjectId) {
 		actualIds = append(actualIds, txnDoc.Id)
 	}
 	c.Assert(actualIds, jc.SameContents, expectedIds)
+}
+
+func (s *PruneSuite) assertDocQueue(c *gc.C, collection string, id interface{}, expectedIds ...bson.ObjectId) {
+	coll := s.db.C(collection)
+	var queueDoc struct {
+		Queue []string `bson:"txn-queue"`
+	}
+	err := coll.FindId(id).One(&queueDoc)
+	c.Assert(err, jc.ErrorIsNil)
+	txnIdsHex := make([]string, len(queueDoc.Queue))
+	for i, token := range queueDoc.Queue {
+		// strip of the _nonce
+		txnIdsHex[i] = token[:24]
+	}
+	expectedHex := make([]string, len(expectedIds))
+	for i, id := range expectedIds {
+		expectedHex[i] = id.Hex()
+	}
+	c.Check(txnIdsHex, gc.DeepEquals, expectedHex)
+}
+
+func (s *PruneSuite) assertStashDocQueue(c *gc.C, collection string, id interface{}, expectedIds ...bson.ObjectId) {
+	// Assert a pending/removed document that is currently in the stash.
+	// We identify it by the collection it would have been in.
+	stashId := bson.D{{"c", collection}, {"id", id}}
+	s.assertDocQueue(c, "txns.stash", stashId, expectedIds...)
 }
 
 func (s *PruneSuite) assertCollCount(c *gc.C, collName string, expectedCount int) {

--- a/txn.go
+++ b/txn.go
@@ -54,6 +54,19 @@ var (
 // TransactionSource defines a function that can return transaction operations to run.
 type TransactionSource func(attempt int) ([]txn.Op, error)
 
+// PruneOptions controls when we will trigger a database prune.
+type PruneOptions struct {
+	// PruneFactor will trigger a prune when the current count of
+	// transactions in the database is greater than old*PruneFactor
+	PruneFactor float32
+	// MinNewTransactions will skip a prune even if pruneFactor is true
+	// if there are less than MinNewTransactions that might be cleaned up.
+	MinNewTransactions int
+	// MaxNewTransactions will force a prune if it sees more than
+	// MaxNewTransactions since the last run.
+	MaxNewTransactions int
+}
+
 // Runner instances applies operations to collections in a database.
 type Runner interface {
 	// RunTransaction applies the specified transaction operations to a database.
@@ -75,7 +88,7 @@ type Runner interface {
 	//
 	//   txn_count >= pruneFactor * txn_count_at_last_prune
 	//
-	MaybePruneTransactions(pruneFactor float32) error
+	MaybePruneTransactions(pruneOpts PruneOptions) error
 }
 
 type txnRunner interface {
@@ -214,8 +227,8 @@ func (tr *transactionRunner) ResumeTransactions() error {
 }
 
 // MaybePruneTransactions is defined on Runner.
-func (tr *transactionRunner) MaybePruneTransactions(pruneFactor float32) error {
-	return maybePrune(tr.db, tr.transactionCollectionName, pruneFactor)
+func (tr *transactionRunner) MaybePruneTransactions(pruneOpts PruneOptions) error {
+	return maybePrune(tr.db, tr.transactionCollectionName, pruneOpts)
 }
 
 // TestHook holds a pair of functions to be called before and after a


### PR DESCRIPTION
This builds on my previous patch to cleanup the txns stash.

The actual changes here are fairly small once that one lands. This just adds CleanupAllCollections and updates the test suite to handle the fact that last-updated-transactions are no longer left in the documents.

It also includes "statuseshistory" as an explicitly omitted table, because it is not worth processing (its big, and never uses txns.)

(Review request: http://reviews.vapour.ws/r/6494/)