### PR TITLE
Abstract out "Completed Transaction" functionality

### DIFF
--- a/cleaner.go
+++ b/cleaner.go
@@ -357,7 +357,7 @@ func (cleaner *collectionCleaner) Cleanup() error {
 // CleanupStash goes through the txns.stash and removes documents that are no longer needed.
 func CleanupStash(db *mgo.Database, oracle Oracle, txnsStash *mgo.Collection) error {
 	cleaner := NewStashCleaner(CollectionConfig{
-		Oracle: 	oracle,
+		Oracle:         oracle,
 		Source:         txnsStash,
 		NumBatchTokens: queueBatchSize,
 		MaxRemoveQueue: maxMemoryTokens,

--- a/export_test.go
+++ b/export_test.go
@@ -3,6 +3,10 @@
 
 package txn
 
+import (
+	"gopkg.in/mgo.v2"
+)
+
 type TxnRunner txnRunner
 
 // Specify the function that creates the txnRunner for testing.
@@ -14,3 +18,16 @@ func SetRunnerFunc(r Runner, f func() TxnRunner) {
 }
 
 var CheckMongoSupportsOut = checkMongoSupportsOut
+
+// NewDBOracleNoOut is only used for testing. It forces the DBOracle to not ask
+// mongo to populate the working set in the aggregation pipeline, which is our
+// compatibility code for older mongo versions.
+func NewDBOracleNoOut(db *mgo.Database, txns *mgo.Collection) (*DBOracle, func(), error) {
+	oracle := &DBOracle{
+		db:            db,
+		txns:          txns,
+		usingMongoOut: false,
+	}
+	cleanup, err := oracle.prepare()
+	return oracle, cleanup, err
+}

--- a/export_test.go
+++ b/export_test.go
@@ -12,3 +12,5 @@ func SetRunnerFunc(r Runner, f func() TxnRunner) {
 		return f()
 	}
 }
+
+var CheckMongoSupportsOut = checkMongoSupportsOut

--- a/oracle.go
+++ b/oracle.go
@@ -1,0 +1,336 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package txn
+
+import (
+	"fmt"
+	"sort"
+
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// DBOracle uses a temporary table on disk to track what transactions are
+// considered completed and purgeable.
+type DBOracle struct {
+	db              *mgo.Database
+	txns            *mgo.Collection
+	working         *mgo.Collection
+	checkedTokens   uint64
+	completedTokens uint64
+	foundTxns       uint64
+}
+
+// OracleIterator is used to walk over the remaining transactions.
+// See the mgo.Iter as a similar iteration mechanism. Standard use is to do:
+// iter := oracle.IterTxns()
+// return EOF when we get to the end of the iterator, or some other error if
+// there is another failure.
+// for txnId := iter.Next(); err != nil; txnId := iter.Next()  {
+// }
+// if err != txn.EOF {
+// }
+type OracleIterator interface {
+	// Grab the next transaction id. Will return nil if there are no
+	// more transactions.
+	Next() (bson.ObjectId, error)
+}
+
+// Oracle is the general interface that is used to track what transactions
+// are considered completed, and can be pruned.
+type Oracle interface {
+	// Prepare is called to set up any cache that the Oracle is going to
+	// be using. It returns a Cleanup function that callers are
+	// responsible for the lifetime.
+	Prepare() (cleanup func(), err error)
+
+	// Count returns the number of transactions that we are working with
+	Count() int
+
+	// CompletedTokens is called with a list of tokens to be checked. The
+	// returned map will have a 'true' for any token that references a
+	// completed transaction.
+	CompletedTokens(tokens []string) (map[string]bool, error)
+
+	// RemoveTxns can be used to flag that a given transaction should not
+	// be considered part of the valid set.
+	RemoveTxns(txnIds []bson.ObjectId) error
+
+	// IterTxns lets you iterate over all of the transactions that have
+	// not been removed.
+	IterTxns() (OracleIterator, error)
+}
+
+// NewDBOracle uses a database collection to manage the queue of remaining
+// transactions.
+func NewDBOracle(db *mgo.Database, txns *mgo.Collection) *DBOracle {
+	return &DBOracle{
+		db:   db,
+		txns: txns,
+	}
+}
+
+var _ Oracle = (*DBOracle)(nil)
+
+func noopCleanup() {}
+
+func (o *DBOracle) Prepare() (func(), error) {
+	if o.working != nil {
+		return noopCleanup, fmt.Errorf("Prepare called twice")
+	}
+	workingSetName := o.txns.Name + ".prunetemp"
+	o.working = o.db.C(workingSetName)
+
+	// Load the ids of all completed and aborted txns into a separate
+	// temporary collection.
+	logger.Debugf("loading all completed transactions")
+	pipe := o.txns.Pipe([]bson.M{
+		// This used to use $in but that's much slower than $gte.
+		{"$match": bson.M{"s": bson.M{"$gte": taborted}}},
+		{"$project": bson.M{"_id": 1}},
+		{"$out": workingSetName},
+	})
+	pipe.Batch(maxBatchDocs)
+	pipe.AllowDiskUse()
+	if err := pipe.All(&bson.D{}); err != nil {
+		o.cleanup()
+		return noopCleanup, fmt.Errorf("reading completed txns: %v", err)
+	}
+	return o.cleanup, nil
+}
+
+func (o *DBOracle) Count() int {
+	if o.working == nil {
+		return -1
+	}
+	count, err := o.working.Count()
+	if err != nil {
+		return -1
+	}
+	return count
+}
+
+func (o *DBOracle) cleanup() {
+	if o.working != nil {
+		name := o.working.Name
+		err := o.working.DropCollection()
+		o.working = nil
+		if err != nil {
+			logger.Warningf("cleanup of %q failed: %v", name, err)
+		}
+	}
+}
+
+// CompletedTokens looks at the list of tokens and finds what referenced txns
+// are completed, and then returns the set of tokens that are completed.
+func (o *DBOracle) CompletedTokens(tokens []string) (map[string]bool, error) {
+	objectIds := make([]bson.ObjectId, 0, len(tokens))
+
+	// The nonce is generated during preparing, and if 2 flushers race,
+	// only one nonce makes it into the final transaction. However, other
+	// nonces can also be considered 'completed'. (afaict, they are ignored,
+	// thus won't be applied and can be considered completed.)
+	for _, token := range tokens {
+		objId := txnTokenToId(token)
+		objectIds = append(objectIds, objId)
+	}
+	query := o.working.Find(bson.M{"_id": bson.M{"$in": objectIds}})
+	query = query.Select(bson.M{"_id": 1})
+	iter := query.Iter()
+	var txnDoc struct {
+		Id bson.ObjectId `bson:"_id"`
+	}
+	foundIdHex := make(map[string]bool, len(objectIds))
+	for iter.Next(&txnDoc) {
+		foundIdHex[txnDoc.Id.Hex()] = true
+	}
+	if err := iter.Close(); err != nil {
+		if err != mgo.ErrNotFound {
+			// Not found is ok, the transactions may not be complete
+			return nil, err
+		}
+	}
+	result := make(map[string]bool, len(foundIdHex))
+	// because multiple tokens could map to a single txn, we iterate the
+	// passed in tokens instead of caching them in the map.
+	for _, token := range tokens {
+		objIdHex := txnTokenToId(token).Hex()
+		if foundIdHex[objIdHex] {
+			result[token] = true
+		}
+	}
+	o.checkedTokens += uint64(len(tokens))
+	o.completedTokens += uint64(len(result))
+	o.foundTxns += uint64(len(foundIdHex))
+	return result, nil
+}
+
+// RemoveTxns can be used to flag that a given transaction should not
+// be considered part of the valid set.
+func (o *DBOracle) RemoveTxns(txnIds []bson.ObjectId) error {
+	_, err := o.working.RemoveAll(bson.M{"_id": bson.M{"$in": txnIds}})
+	if err != nil {
+		return fmt.Errorf("error removing transaction ids: %v", err)
+	}
+	return nil
+}
+
+type dbIterWrapper struct {
+	iter *mgo.Iter
+}
+
+var _ OracleIterator = (*dbIterWrapper)(nil)
+
+var EOF = fmt.Errorf("end of transaction ids")
+
+func (d *dbIterWrapper) Next() (bson.ObjectId, error) {
+	var txnId struct {
+		Id bson.ObjectId `bson:"_id"`
+	}
+	if d.iter.Next(&txnId) {
+		return txnId.Id, nil
+	}
+	if err := d.iter.Close(); err != nil {
+		return txnId.Id, err
+	}
+	return txnId.Id, EOF
+}
+func (d *dbIterWrapper) Close() error {
+	return d.iter.Close()
+}
+
+// IterTxns lets you iterate over all of the transactions that have
+// not been removed.
+func (o *DBOracle) IterTxns() (OracleIterator, error) {
+	iter := o.working.Find(nil).Select(bson.M{"_id": 1}).Iter()
+	return &dbIterWrapper{iter: iter}, nil
+}
+
+// MemOracle uses a temporary table on disk to track what transactions are
+// considered completed and purgeable.
+type MemOracle struct {
+	txns            *mgo.Collection
+	completed       map[bson.ObjectId]bool
+	checkedTokens   uint64
+	completedTokens uint64
+	foundTxns       uint64
+}
+
+// NewMemOracle uses an in-memory map to manage the queue of  remaining
+// transactions.
+func NewMemOracle(txns *mgo.Collection) *MemOracle {
+	return &MemOracle{
+		txns: txns,
+	}
+}
+
+var _ Oracle = (*MemOracle)(nil)
+
+func (o *MemOracle) Prepare() (func(), error) {
+	if o.completed != nil {
+		return noopCleanup, fmt.Errorf("Prepare called twice")
+	}
+	// Load the ids of all completed and aborted txns into a separate
+	// temporary collection.
+	logger.Debugf("loading all completed transactions")
+	pipe := o.txns.Pipe([]bson.M{
+		// This used to use $in but that's much slower than $gte.
+		{"$match": bson.M{"s": bson.M{"$gte": taborted}}},
+		{"$project": bson.M{"_id": 1}},
+	})
+	pipe.Batch(maxBatchDocs)
+	pipe.AllowDiskUse()
+	var txnId struct {
+		Id bson.ObjectId `bson:"_id"`
+	}
+	completed := make(map[bson.ObjectId]bool, 1000)
+	iter := pipe.Iter()
+	for iter.Next(&txnId) {
+		completed[txnId.Id] = true
+	}
+	if err := iter.Close(); err != nil {
+		return noopCleanup, err
+	}
+	o.completed = completed
+	return o.cleanup, nil
+}
+
+func (o *MemOracle) Count() int {
+	if o.completed != nil {
+		return len(o.completed)
+	}
+	return -1
+}
+
+func (o *MemOracle) cleanup() {
+	if o.completed != nil {
+		o.completed = nil
+	}
+}
+
+// CompletedTokens looks at the list of tokens and finds what referenced txns
+// are completed, and then returns the set of tokens that are completed.
+func (o *MemOracle) CompletedTokens(tokens []string) (map[string]bool, error) {
+	result := make(map[string]bool, len(tokens))
+
+	// The nonce is generated during preparing, and if 2 flushers race,
+	// only one nonce makes it into the final transaction. However, other
+	// nonces can also be considered 'completed'. (afaict, they are ignored,
+	// thus won't be applied and can be considered completed.)
+	for _, token := range tokens {
+		objId := txnTokenToId(token)
+		if _, ok := o.completed[objId]; ok {
+			result[token] = true
+			// this isn't exactly the same metric as the other
+			// one, which noticed when the same txn object was
+			// referred to by a different token
+			o.foundTxns += 1
+		}
+	}
+	o.checkedTokens += uint64(len(tokens))
+	o.completedTokens += uint64(len(result))
+	return result, nil
+}
+
+// RemoveTxns can be used to flag that a given transaction should not
+// be considered part of the valid set.
+func (o *MemOracle) RemoveTxns(txnIds []bson.ObjectId) error {
+	for _, txnId := range txnIds {
+		delete(o.completed, txnId)
+	}
+	return nil
+}
+
+type memIterator struct {
+	txnIds []bson.ObjectId
+}
+
+var _ OracleIterator = (*memIterator)(nil)
+
+func (m *memIterator) Next() (bson.ObjectId, error) {
+	var txnId bson.ObjectId
+	if len(m.txnIds) == 0 {
+		return txnId, EOF
+	}
+	txnId = m.txnIds[0]
+	m.txnIds = m.txnIds[1:]
+	return txnId, nil
+}
+
+type sortedTxnIds []bson.ObjectId
+
+func (s sortedTxnIds) Len() int           { return len(s) }
+func (s sortedTxnIds) Less(i, j int) bool { return s[i] < s[j] }
+func (s sortedTxnIds) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+// IterTxns lets you iterate over all of the transactions that have
+// not been removed.
+func (o *MemOracle) IterTxns() (OracleIterator, error) {
+	all := make([]bson.ObjectId, 0, len(o.completed))
+	for txnId, _ := range o.completed {
+		all = append(all, txnId)
+	}
+	sort.Sort(sortedTxnIds(all))
+	return &memIterator{txnIds: all}, nil
+}

--- a/oracle.go
+++ b/oracle.go
@@ -110,12 +110,18 @@ func (o *DBOracle) prepareWorkingDirectly(pipeline []bson.M) error {
 	var txnDoc struct {
 		Id bson.ObjectId `bson:"_id"`
 	}
+	t := newSimpleTimer(logInterval)
+	docCount := 0
 	for iter.Next(&txnDoc) {
 		// TODO(jam) 2017-04-10: Evaluate if it is worth batching up the
 		// documents read, to do inserts of many documents at once.
 		err := o.working.Insert(txnDoc)
 		if err != nil {
 			return err
+		}
+		docCount++
+		if t.isAfter() {
+			logger.Debugf("copied %d documents", docCount)
 		}
 	}
 	return iter.Close()

--- a/oracle.go
+++ b/oracle.go
@@ -207,7 +207,7 @@ func (o *DBOracle) IterTxns() (OracleIterator, error) {
 // considered completed and purgeable.
 type MemOracle struct {
 	txns            *mgo.Collection
-	completed       map[bson.ObjectId]bool
+	completed       map[bson.ObjectId]struct{}
 	checkedTokens   uint64
 	completedTokens uint64
 	foundTxns       uint64
@@ -242,10 +242,10 @@ func (o *MemOracle) prepare() error {
 	var txnId struct {
 		Id bson.ObjectId `bson:"_id"`
 	}
-	completed := make(map[bson.ObjectId]bool, 1000)
+	completed := make(map[bson.ObjectId]struct{})
 	iter := pipe.Iter()
 	for iter.Next(&txnId) {
-		completed[txnId.Id] = true
+		completed[txnId.Id] = struct{}{}
 	}
 	if err := iter.Close(); err != nil {
 		return err

--- a/oracle.go
+++ b/oracle.go
@@ -117,6 +117,8 @@ func (o *DBOracle) prepareWorkingDirectly(pipeline []bson.M) error {
 	// copied 11M transaction ids.
 	// With a 1000 item batch, it took 20min to do copy 36M documents (approx
 	// 10x speedup)
+	// For reference, it is about 9min to use $out, and 13min to read the data
+	// into memory.
 	docsToInsert := make([]interface{}, 0, maxBulkOps)
 	flush := func() error {
 		if len(docsToInsert) == 0 {
@@ -315,6 +317,8 @@ func (o *MemOracle) prepare() error {
 	}
 	// Load the ids of all completed and aborted txns into a separate
 	// temporary collection.
+	// Max memory consumed when dealing with 36M transactions was around 4GB
+	// when testing this.
 	logger.Debugf("loading all completed transactions")
 	pipe := o.txns.Pipe([]bson.M{
 		// This used to use $in but that's much slower than $gte.

--- a/oracle.go
+++ b/oracle.go
@@ -314,6 +314,7 @@ func (o *MemOracle) prepare() error {
 	docCount := 0
 	for iter.Next(&txnId) {
 		completed[txnId.Id] = struct{}{}
+		docCount++
 		if t.isAfter() {
 			logger.Debugf("loaded %d documents", docCount)
 		}

--- a/oracle_test.go
+++ b/oracle_test.go
@@ -34,6 +34,13 @@ var _ = gc.Suite(&DBOracleSuite{
 	},
 })
 
+func (s *DBOracleSuite) SetUpTest(c *gc.C) {
+	s.TxnSuite.SetUpTest(c)
+	if !jujutxn.CheckMongoSupportsOut(s.db) {
+		c.Skip("mongo does not support $out in aggregation pipelines")
+	}
+}
+
 func memOracleFunc(db *mgo.Database, c *mgo.Collection) jujutxn.Oracle {
 	return jujutxn.NewMemOracle(c)
 }
@@ -103,6 +110,7 @@ func (s *OracleSuite) TestRemovedTxns(c *gc.C) {
 	c.Assert(oracle, gc.NotNil)
 	cleanup, err := oracle.Prepare()
 	defer cleanup()
+	c.Assert(err, jc.ErrorIsNil)
 	token1 := s.txnToToken(c, txnId1)
 	token2 := s.txnToToken(c, txnId2)
 	completed, err := oracle.CompletedTokens([]string{token1, token2})
@@ -140,6 +148,7 @@ func (s *OracleSuite) TestIterTxns(c *gc.C) {
 	c.Assert(oracle, gc.NotNil)
 	cleanup, err := oracle.Prepare()
 	defer cleanup()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Check(oracle.Count(), gc.Equals, 3)
 	oracle.RemoveTxns([]bson.ObjectId{txnId2})
 	c.Check(oracle.Count(), gc.Equals, 2)

--- a/oracle_test.go
+++ b/oracle_test.go
@@ -34,13 +34,6 @@ var _ = gc.Suite(&DBOracleSuite{
 	},
 })
 
-func (s *DBOracleSuite) SetUpTest(c *gc.C) {
-	s.TxnSuite.SetUpTest(c)
-	if !jujutxn.CheckMongoSupportsOut(s.db) {
-		c.Skip("mongo does not support $out in aggregation pipelines")
-	}
-}
-
 func memOracleFunc(db *mgo.Database, c *mgo.Collection) jujutxn.Oracle {
 	return jujutxn.NewMemOracle(c)
 }
@@ -66,6 +59,12 @@ func (s *OracleSuite) txnToToken(c *gc.C, id bson.ObjectId) string {
 }
 
 func (s *OracleSuite) TestKnownAndUnknownTxns(c *gc.C) {
+	// We can't put the Skip into SetUpTest because we are using a
+	// database connection, which needs to get cleaned up in TearDownTest
+	// and if you Skip in a SetUpTest it skips running the TearDownTest.
+	if !jujutxn.CheckMongoSupportsOut(s.db) {
+		c.Skip("mongo does not support $out in aggregation pipelines")
+	}
 	completedTxnId := s.runTxn(c, txn.Op{
 		C: "coll",
 		Id: 0,
@@ -96,6 +95,9 @@ func (s *OracleSuite) TestKnownAndUnknownTxns(c *gc.C) {
 }
 
 func (s *OracleSuite) TestRemovedTxns(c *gc.C) {
+	if !jujutxn.CheckMongoSupportsOut(s.db) {
+		c.Skip("mongo does not support $out in aggregation pipelines")
+	}
 	txnId1 := s.runTxn(c, txn.Op{
 		C: "coll",
 		Id: 0,
@@ -129,6 +131,9 @@ func (s *OracleSuite) TestRemovedTxns(c *gc.C) {
 }
 
 func (s *OracleSuite) TestIterTxns(c *gc.C) {
+	if !jujutxn.CheckMongoSupportsOut(s.db) {
+		c.Skip("mongo does not support $out in aggregation pipelines")
+	}
 	txnId1 := s.runTxn(c, txn.Op{
 		C: "coll",
 		Id: 0,

--- a/oracle_test.go
+++ b/oracle_test.go
@@ -1,0 +1,162 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package txn_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+
+	jujutxn "github.com/juju/txn"
+)
+
+// OracleSuite will be run against all oracle implementations.
+type OracleSuite struct {
+	TxnSuite
+	OracleFunc func(*mgo.Database, *mgo.Collection) jujutxn.Oracle
+}
+
+func dbOracleFunc(db *mgo.Database, c *mgo.Collection) jujutxn.Oracle {
+	return jujutxn.NewDBOracle(db, c)
+}
+
+// DBOracleSuite causes the test suite to run against the DBOracle implementation
+type DBOracleSuite struct {
+	OracleSuite
+}
+
+var _ = gc.Suite(&DBOracleSuite{
+	OracleSuite:OracleSuite{
+		OracleFunc: dbOracleFunc,
+	},
+})
+
+func memOracleFunc(db *mgo.Database, c *mgo.Collection) jujutxn.Oracle {
+	return jujutxn.NewMemOracle(c)
+}
+
+type MemOracleSuite struct {
+	OracleSuite
+}
+
+var _ = gc.Suite(&MemOracleSuite{
+	OracleSuite:OracleSuite{
+		OracleFunc: memOracleFunc,
+	},
+})
+
+func (s *OracleSuite) txnToToken(c *gc.C, id bson.ObjectId) string {
+	var noncer struct {
+		Nonce string `bson:"n"`
+	}
+
+	err := s.txns.FindId(id).Select(bson.M{"n": 1}).One(&noncer)
+	c.Assert(err, jc.ErrorIsNil)
+	return id.Hex() + "_" + noncer.Nonce
+}
+
+func (s *OracleSuite) TestKnownAndUnknownTxns(c *gc.C) {
+	completedTxnId := s.runTxn(c, txn.Op{
+		C: "coll",
+		Id: 0,
+		Insert: bson.M{},
+	})
+	pendingTxnId := s.runInterruptedTxn(c, txn.Op{
+		C: "coll",
+		Id: 0,
+		Update: bson.M{},
+	})
+	oracle := s.OracleFunc(s.db, s.txns)
+	c.Assert(oracle, gc.NotNil)
+	cleanup, err := oracle.Prepare()
+	defer cleanup()
+	c.Assert(err, jc.ErrorIsNil)
+	// One is the real one, one is a flusher that raced and failed
+	completedToken1 := s.txnToToken(c, completedTxnId)
+	completedToken2 := completedTxnId.Hex() + "_56780123"
+	pendingToken := s.txnToToken(c, pendingTxnId)
+	unknownToken := "0123456789abcdef78901234_deadbeef"
+	tokens := []string{completedToken1, completedToken2, pendingToken, unknownToken}
+	completed, err := oracle.CompletedTokens(tokens)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(completed, jc.DeepEquals, map[string]bool{
+		completedToken1: true,
+		completedToken2: true,
+	})
+}
+
+func (s *OracleSuite) TestRemovedTxns(c *gc.C) {
+	txnId1 := s.runTxn(c, txn.Op{
+		C: "coll",
+		Id: 0,
+		Insert: bson.M{},
+	})
+	txnId2 := s.runTxn(c, txn.Op{
+		C: "coll",
+		Id: 1,
+		Insert: bson.M{},
+	})
+	oracle := s.OracleFunc(s.db, s.txns)
+	c.Assert(oracle, gc.NotNil)
+	cleanup, err := oracle.Prepare()
+	defer cleanup()
+	token1 := s.txnToToken(c, txnId1)
+	token2 := s.txnToToken(c, txnId2)
+	completed, err := oracle.CompletedTokens([]string{token1, token2})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(completed, jc.DeepEquals, map[string]bool{
+		token1: true,
+		token2: true,
+	})
+	err = oracle.RemoveTxns([]bson.ObjectId{txnId1})
+	c.Assert(err, jc.ErrorIsNil)
+	completed, err = oracle.CompletedTokens([]string{token1, token2})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(completed, jc.DeepEquals, map[string]bool{
+		token2: true,
+	})
+}
+
+func (s *OracleSuite) TestIterTxns(c *gc.C) {
+	txnId1 := s.runTxn(c, txn.Op{
+		C: "coll",
+		Id: 0,
+		Insert: bson.M{},
+	})
+	txnId2 := s.runTxn(c, txn.Op{
+		C: "coll",
+		Id: 1,
+		Insert: bson.M{},
+	})
+	txnId3 := s.runTxn(c, txn.Op{
+		C: "coll",
+		Id: 2,
+		Insert: bson.M{},
+	})
+	oracle := s.OracleFunc(s.db, s.txns)
+	c.Assert(oracle, gc.NotNil)
+	cleanup, err := oracle.Prepare()
+	defer cleanup()
+	c.Check(oracle.Count(), gc.Equals, 3)
+	oracle.RemoveTxns([]bson.ObjectId{txnId2})
+	c.Check(oracle.Count(), gc.Equals, 2)
+	all := make([]bson.ObjectId, 0)
+	iter, err := oracle.IterTxns()
+	c.Assert(err, jc.ErrorIsNil)
+	var txnId bson.ObjectId
+	for txnId, err = iter.Next(); err == nil; txnId, err = iter.Next() {
+		all = append(all, txnId)
+	}
+	c.Assert(err, gc.Equals, jujutxn.EOF)
+	// Do we care about the order here?
+	c.Check(all, jc.DeepEquals, []bson.ObjectId{txnId1, txnId3})
+}
+
+func (s *OracleSuite) TestCount(c *gc.C) {
+	oracle := s.OracleFunc(s.db, s.txns)
+	// Before calling Prepare, Count is invalid
+	c.Check(oracle.Count(), gc.Equals, -1)
+}

--- a/prune.go
+++ b/prune.go
@@ -122,8 +122,7 @@ func checkMongoSupportsOut(db *mgo.Database) bool {
 	return true
 }
 
-
-func getOracle(db *mgo.Database, txns *mgo.Collection, txnsCount int, maxMemoryTxns int) Oracle {
+func getOracle(db *mgo.Database, txns *mgo.Collection, txnsCount int, maxMemoryTxns int) (Oracle, func(), error) {
 	if txnsCount < maxMemoryTxns {
 		return NewMemOracle(txns)
 	}
@@ -193,8 +192,7 @@ func CleanAndPrune(db *mgo.Database, txns *mgo.Collection, txnsCountHint int) er
 		}
 		txnsCountHint = txnsCount
 	}
-	oracle := getOracle(db, txns, txnsCountHint, maxMemoryTokens)
-	cleanup, err := oracle.Prepare()
+	oracle, cleanup, err := getOracle(db, txns, txnsCountHint, maxMemoryTokens)
 	defer cleanup()
 	if err != nil {
 		return err

--- a/prune.go
+++ b/prune.go
@@ -101,7 +101,8 @@ func shouldPrune(oldCount, newCount int, pruneOptions PruneOptions) (bool, strin
 }
 
 // checkMongoSupportsOut verifies that Mongo supports "$out" in an aggregation
-// pipeline. This was introduced in Mongo 3.2
+// pipeline. This was introduced in Mongo 2.6
+// https://docs.mongodb.com/manual/reference/operator/aggregation/out/
 func checkMongoSupportsOut(db *mgo.Database) bool {
 	var dbInfo struct {
 		VersionArray []int `bson:"versionArray"`
@@ -109,12 +110,13 @@ func checkMongoSupportsOut(db *mgo.Database) bool {
 	if err := db.Run(bson.M{"buildInfo": 1}, &dbInfo); err != nil {
 		return false
 	}
+	logger.Debugf("buildInfo reported: %v", dbInfo.VersionArray)
 	if len(dbInfo.VersionArray) < 2 {
 		return false
 	}
-	// Check if we are < 3.2
-	if dbInfo.VersionArray[0] < 3 ||
-		(dbInfo.VersionArray[0] == 3 && dbInfo.VersionArray[1] < 2) {
+	// Check if we are < 2.6
+	if dbInfo.VersionArray[0] < 2 ||
+		(dbInfo.VersionArray[0] == 2 && dbInfo.VersionArray[1] < 6) {
 		return false
 	}
 	return true

--- a/prune.go
+++ b/prune.go
@@ -114,21 +114,23 @@ func checkMongoSupportsOut(db *mgo.Database) bool {
 	if len(dbInfo.VersionArray) < 2 {
 		return false
 	}
-	// Check if we are < 2.6
-	if dbInfo.VersionArray[0] < 2 ||
-		(dbInfo.VersionArray[0] == 2 && dbInfo.VersionArray[1] < 6) {
-		return false
-	}
-	return true
+	// Check if we are at least 2.6
+	v := dbInfo.VersionArray
+	return v[0] > 2 || (v[0] == 2 && v[1] >= 6)
 }
 
 func getOracle(db *mgo.Database, txns *mgo.Collection, txnsCount int, maxMemoryTxns int) (Oracle, func(), error) {
+	// If we don't have very many transactions, just use the in-memory version
 	if txnsCount < maxMemoryTxns {
 		return NewMemOracle(txns)
 	}
-	// We are using Mongo 3.2 with a large txn array, use the db-based
-	// oracle
 	if !checkMongoSupportsOut(db) {
+		// Mongo 2.4 doesn't support pipeline's using $out, so we have to fall
+		// back to the memory version.
+		// TODO(jam) 2017-04-10: https://github.com/juju/mgopurge/issues/8
+		// We should probably just have a flag on DBOracle that creates the
+		// working set directly, rather than OOMing because we loaded
+		// everything into memory
 		return NewMemOracle(txns)
 	}
 	return NewDBOracle(db, txns)

--- a/txnsuite_test.go
+++ b/txnsuite_test.go
@@ -23,11 +23,11 @@ type TxnSuite struct {
 func (s *TxnSuite) SetUpSuite(c *gc.C) {
 	s.IsolationSuite.SetUpSuite(c)
 	s.MgoSuite.SetUpSuite(c)
-	// Make sure we've removed any Chaos
-	s.AddCleanup(func(*gc.C) { txn.SetChaos(txn.Chaos{})})
 }
 
 func (s *TxnSuite) TearDownSuite(c *gc.C) {
+	// Make sure we've removed any Chaos
+	txn.SetChaos(txn.Chaos{})
 	s.MgoSuite.TearDownSuite(c)
 	s.IsolationSuite.TearDownSuite(c)
 }
@@ -36,8 +36,6 @@ func (s *TxnSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.MgoSuite.SetUpTest(c)
 	txn.SetChaos(txn.Chaos{})
-	// Make sure we've removed any Chaos
-	s.AddCleanup(func(*gc.C) { txn.SetChaos(txn.Chaos{})})
 
 	s.db = s.Session.DB("mgo-test")
 	s.txns = s.db.C("txns")
@@ -45,6 +43,8 @@ func (s *TxnSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *TxnSuite) TearDownTest(c *gc.C) {
+	// Make sure we've removed any Chaos
+	txn.SetChaos(txn.Chaos{})
 	s.MgoSuite.TearDownTest(c)
 	s.IsolationSuite.TearDownTest(c)
 }

--- a/txnsuite_test.go
+++ b/txnsuite_test.go
@@ -122,4 +122,3 @@ func (s *TxnSuite) getCollCount(c *gc.C, collName string) int {
 	c.Assert(err, jc.ErrorIsNil)
 	return n
 }
-

--- a/txnsuite_test.go
+++ b/txnsuite_test.go
@@ -1,0 +1,125 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package txn_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/txn"
+)
+
+type TxnSuite struct {
+	testing.IsolationSuite
+	testing.MgoSuite
+	db     *mgo.Database
+	txns   *mgo.Collection
+	runner *txn.Runner
+}
+
+func (s *TxnSuite) SetUpSuite(c *gc.C) {
+	s.IsolationSuite.SetUpSuite(c)
+	s.MgoSuite.SetUpSuite(c)
+	// Make sure we've removed any Chaos
+	s.AddCleanup(func(*gc.C) { txn.SetChaos(txn.Chaos{})})
+}
+
+func (s *TxnSuite) TearDownSuite(c *gc.C) {
+	s.MgoSuite.TearDownSuite(c)
+	s.IsolationSuite.TearDownSuite(c)
+}
+
+func (s *TxnSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.MgoSuite.SetUpTest(c)
+	txn.SetChaos(txn.Chaos{})
+	// Make sure we've removed any Chaos
+	s.AddCleanup(func(*gc.C) { txn.SetChaos(txn.Chaos{})})
+
+	s.db = s.Session.DB("mgo-test")
+	s.txns = s.db.C("txns")
+	s.runner = txn.NewRunner(s.txns)
+}
+
+func (s *TxnSuite) TearDownTest(c *gc.C) {
+	s.MgoSuite.TearDownTest(c)
+	s.IsolationSuite.TearDownTest(c)
+}
+
+func (s *TxnSuite) runTxn(c *gc.C, ops ...txn.Op) bson.ObjectId {
+	txnId := bson.NewObjectId()
+	err := s.runner.Run(ops, txnId, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	return txnId
+}
+
+func (s *TxnSuite) runFailingTxn(c *gc.C, expectedErr error, ops ...txn.Op) bson.ObjectId {
+	txnId := bson.NewObjectId()
+	err := s.runner.Run(ops, txnId, nil)
+	c.Assert(err, gc.Equals, expectedErr)
+	return txnId
+}
+
+// runInterruptedTxn starts a transaction, but interrupts it just before it gets applied.
+func (s *TxnSuite) runInterruptedTxn(c *gc.C, ops ...txn.Op) bson.ObjectId {
+	txn.SetChaos(txn.Chaos{
+		KillChance: 1,
+		Breakpoint: "set-applying",
+	})
+	txnId := s.runFailingTxn(c, txn.ErrChaos, ops...)
+	txn.SetChaos(txn.Chaos{})
+	return txnId
+}
+
+func (s *TxnSuite) assertTxns(c *gc.C, expectedIds ...bson.ObjectId) {
+	var actualIds []bson.ObjectId
+	var txnDoc struct {
+		Id bson.ObjectId `bson:"_id"`
+	}
+	iter := s.txns.Find(nil).Select(bson.M{"_id": 1}).Iter()
+	for iter.Next(&txnDoc) {
+		actualIds = append(actualIds, txnDoc.Id)
+	}
+	c.Assert(actualIds, jc.SameContents, expectedIds)
+}
+
+func (s *TxnSuite) assertDocQueue(c *gc.C, collection string, id interface{}, expectedIds ...bson.ObjectId) {
+	coll := s.db.C(collection)
+	var queueDoc struct {
+		Queue []string `bson:"txn-queue"`
+	}
+	err := coll.FindId(id).One(&queueDoc)
+	c.Assert(err, jc.ErrorIsNil)
+	txnIdsHex := make([]string, len(queueDoc.Queue))
+	for i, token := range queueDoc.Queue {
+		// strip of the _nonce
+		txnIdsHex[i] = token[:24]
+	}
+	expectedHex := make([]string, len(expectedIds))
+	for i, id := range expectedIds {
+		expectedHex[i] = id.Hex()
+	}
+	c.Check(txnIdsHex, gc.DeepEquals, expectedHex)
+}
+
+func (s *TxnSuite) assertStashDocQueue(c *gc.C, collection string, id interface{}, expectedIds ...bson.ObjectId) {
+	// Assert a pending/removed document that is currently in the stash.
+	// We identify it by the collection it would have been in.
+	stashId := bson.D{{"c", collection}, {"id", id}}
+	s.assertDocQueue(c, "txns.stash", stashId, expectedIds...)
+}
+
+func (s *TxnSuite) assertCollCount(c *gc.C, collName string, expectedCount int) {
+	count := s.getCollCount(c, collName)
+	c.Assert(count, gc.Equals, expectedCount)
+}
+
+func (s *TxnSuite) getCollCount(c *gc.C, collName string) int {
+	n, err := s.db.C(collName).Count()
+	c.Assert(err, jc.ErrorIsNil)
+	return n
+}
+


### PR DESCRIPTION
This brings in an Oracle interface, which allows us to track completed transactions either in-memory or using the $out aggregation.

I decided to use a check on how-many-transactions there are as to whether we would use the in-memory one.  My suspicion is that pruning got faster because we were deleting in database order, rather than just because of disk vs memory. So the MemOracle sorts the transaction ids before returning them.

I haven't had a chance to test this on the big database, or on a live test server, so it does need a bit of direct testing to flush out anything else.

I also ran into the fact that doing c.Skip() in SetUpTest causes go-check to also skip calling TearDownTest which sucks, cause it means I can't put the db version check into a common place. (SetUpSuite doesn't have the Session yet, and SetUpTest causes the next TearDownTest that does get called to fail with "sockets left dirty".) We can't even use AddCleanup because if it is skipping TearDown there is nothing that will run the cleanup steps. The other lovely problem is that it doesn't fail until it runs *another* test.

Anyway, this should allow us to run just fine on Mongo 2.4 (2.6 introduced $out). And it means that if we are going to build the temporary table, we can take advantage of it being there for the purposes of pruning. It also provides a single CleanAndPrune function (name suggestions welcome), which allows us to run all the steps from a single call. If you prefer, we could just call that thing PruneTxns and change the internals into several steps from there.


(Review request: http://reviews.vapour.ws/r/6504/)