### PR TITLE
Don't create transactions that have no operations.

### DIFF
--- a/txn.go
+++ b/txn.go
@@ -166,7 +166,7 @@ func (tr *transactionRunner) Run(transactions TransactionSource) error {
 		if err == ErrTransientFailure {
 			continue
 		}
-		if err == ErrNoOperations {
+		if err == ErrNoOperations || len(ops) == 0{
 			return nil
 		}
 		if err != nil {


### PR DESCRIPTION
This may fix: https://bugs.launchpad.net/juju/+bug/1680786
It doesn't let us know who is creating no-op transactions,
but it does feel like it isn't worth committing them to
the database.

We did already have ErrNoOperations to signal something similar, but it seems to me that we should either treat no-operations as either the same thing, *or* we should actually treat it as an error. If you'd prefer an error, I can do that, but we then need to track down the places that are creating these, so we don't have production failures.


(Review request: http://reviews.vapour.ws/r/6508/)