### PR TITLE
Properly test no-op does the right thing, as does real errors.

### DIFF
--- a/txn.go
+++ b/txn.go
@@ -166,11 +166,15 @@ func (tr *transactionRunner) Run(transactions TransactionSource) error {
 		if err == ErrTransientFailure {
 			continue
 		}
-		if err == ErrNoOperations || len(ops) == 0{
+		if err == ErrNoOperations {
 			return nil
 		}
 		if err != nil {
 			return err
+		}
+		if len(ops) == 0 {
+			// Treat this the same as ErrNoOperations but don't suppress other errors.
+			return nil
 		}
 		if err := tr.RunTransaction(ops); err == nil {
 			return nil


### PR DESCRIPTION
Oddly enough we didn't have a test that we handled errors correctly.
The issue is that often when raising an error, we also set the ops to empty,
so we have to check the error before we do the rest.
Add a test that we handle these cases correctly.

(Review request: http://reviews.vapour.ws/r/6516/)