### PR TITLE
Add logging information about the pruning result.

### DIFF
--- a/prune.go
+++ b/prune.go
@@ -125,12 +125,14 @@ func maybePrune(db *mgo.Database, txnsName string, pruneOpts PruneOptions) error
 	}
 
 	required, rationale := shouldPrune(lastTxnsCount, txnsCount, pruneOpts)
-	logger.Infof("txns after last prune: %d, txns now: %d, pruning required: %v %s",
-		lastTxnsCount, txnsCount, required, rationale)
 
 	if !required {
+		logger.Infof("txns after last prune: %d, txns now: %d, not pruning: %s",
+			lastTxnsCount, txnsCount, rationale)
 		return nil
 	}
+	logger.Infof("txns after last prune: %d, txns now: %d, pruning: %s",
+		lastTxnsCount, txnsCount, rationale)
 	started := time.Now()
 
 	stashDocsBefore, err := txnsStash.Count()

--- a/prune.go
+++ b/prune.go
@@ -138,7 +138,7 @@ func maybePrune(db *mgo.Database, txnsName string, pruneOpts PruneOptions) error
 		return fmt.Errorf("failed to retrieve starting %q count: %v", txnsStashName, err)
 	}
 
-	err = CleanAndPrune(db, txns, txnsCount)
+	stats, err := CleanAndPrune(db, txns, txnsCount)
 	completed := time.Now()
 
 	txnsCountAfter, err := txns.Count()
@@ -149,43 +149,66 @@ func maybePrune(db *mgo.Database, txnsName string, pruneOpts PruneOptions) error
 	if err != nil {
 		return fmt.Errorf("failed to retrieve final %q count: %v", txnsStashName, err)
 	}
-	logger.Infof("txn pruning complete. txns now: %d", txnsCountAfter)
+	elapsed := time.Since(started)
+	logger.Infof("txn pruning complete after %v. txns now: %d, inspected %d collections, %d docs (%d cleaned)\n   removed %d stash docs and %d txn docs",
+		elapsed, txnsCountAfter, stats.CollectionsInspected, stats.DocsInspected, stats.DocsCleaned, stats.StashDocumentsRemoved, stats.TransactionsRemoved)
 	return writePruneTxnsCount(txnsPrune, started, completed, txnsCount, txnsCountAfter,
 		stashDocsBefore, stashDocsAfter)
 
 	return nil
 }
 
+// CleanupStats gives some numbers as to what work was done as part of
+// CleanupAndPrune.
+type CleanupStats struct {
+
+	// CollectionsInspected is the total number of collections we looked at for documents
+	CollectionsInspected int
+
+	// DocsInspected is how many documents we loaded to evaluate their txn queues
+	DocsInspected int
+
+	// DocsCleaned is how many documents we Updated to remove entries from their txn queue.
+	DocsCleaned int
+
+	// StashDocumentsRemoved is how many total documents we remove from txns.stash
+	StashDocumentsRemoved int
+
+	// StashDocumentsRemoved is how many documents we remove from txns
+	TransactionsRemoved int
+}
+
 // CleanAndPrune runs the cleanup steps, and then follows up with pruning all
 // of the transactions that are no longer referenced.
-func CleanAndPrune(db *mgo.Database, txns *mgo.Collection, txnsCountHint int) error {
+func CleanAndPrune(db *mgo.Database, txns *mgo.Collection, txnsCountHint int) (CleanupStats, error) {
+	var stats CleanupStats
 	if txnsCountHint <= 0 {
 		txnsCount, err := txns.Count()
 		if err != nil {
-			return err
+			return stats, err
 		}
 		txnsCountHint = txnsCount
 	}
 	oracle, cleanup, err := getOracle(db, txns, txnsCountHint, maxMemoryTokens)
 	defer cleanup()
 	if err != nil {
-		return err
+		return stats, err
 	}
 	txnsStashName := txns.Name + ".stash"
 	txnsStash := db.C(txnsStashName)
 
-	if err := CleanupStash(db, oracle, txnsStash); err != nil {
-		return err
+	if err := cleanupStash(db, oracle, txnsStash, &stats); err != nil {
+		return stats, err
 	}
 
-	if err := CleanupAllCollections(db, oracle, txns.Name); err != nil {
-		return err
+	if err := cleanupAllCollections(db, oracle, txns.Name, &stats); err != nil {
+		return stats, err
 	}
 
-	if err := PruneTxns(db, oracle, txns); err != nil {
-		return err
+	if err := PruneTxns(db, oracle, txns, &stats); err != nil {
+		return stats, err
 	}
-	return nil
+	return stats, nil
 }
 
 // getPruneLastTxnsCount will return how many documents were in 'txns' the
@@ -261,7 +284,7 @@ func txnsPruneC(txnsName string) string {
 // TODO(mjs) - this knows way too much about mgo/txn's internals and
 // with a bit of luck something like this will one day be part of
 // mgo/txn.
-func PruneTxns(db *mgo.Database, oracle Oracle, txns *mgo.Collection) error {
+func PruneTxns(db *mgo.Database, oracle Oracle, txns *mgo.Collection, stats *CleanupStats) error {
 	count := oracle.Count()
 	logger.Debugf("%d completed txns found", count)
 
@@ -293,6 +316,9 @@ func PruneTxns(db *mgo.Database, oracle Oracle, txns *mgo.Collection) error {
 		query.Batch(maxBatchDocs)
 		iter := query.Iter()
 		for iter.Next(&tDoc) {
+			if stats != nil {
+				stats.DocsInspected += 1
+			}
 			for _, token := range tDoc.Queue {
 				txnId := txnTokenToId(token)
 				toRemove = append(toRemove, txnId)
@@ -344,6 +370,9 @@ func PruneTxns(db *mgo.Database, oracle Oracle, txns *mgo.Collection) error {
 	if loopErr != EOF {
 		return loopErr
 	}
+	if stats != nil {
+		stats.TransactionsRemoved += remover.removed
+	}
 
 	logger.Debugf("pruning completed: removed %d txns", remover.removed)
 	return nil
@@ -382,8 +411,8 @@ func txnCollections(inNames []string, txnsName string) []string {
 	return outNames
 }
 
-// CleanupAllCollections iterates all collections that might have transaction queues and checks them to see if
-func CleanupAllCollections(db *mgo.Database, oracle Oracle, txnsName string) error {
+// cleanupAllCollections iterates all collections that might have transaction queues and checks them to see if
+func cleanupAllCollections(db *mgo.Database, oracle Oracle, txnsName string, stats *CleanupStats) error {
 	collNames, err := db.CollectionNames()
 	if err != nil {
 		return fmt.Errorf("reading collection names: %v", err)
@@ -397,6 +426,11 @@ func CleanupAllCollections(db *mgo.Database, oracle Oracle, txnsName string) err
 		})
 		if err := cleaner.Cleanup(); err != nil {
 			return err
+		}
+		if stats != nil {
+			stats.CollectionsInspected += 1
+			stats.DocsInspected += cleaner.stats.DocCount
+			stats.DocsCleaned += cleaner.stats.UpdatedDocCount
 		}
 	}
 	return nil


### PR DESCRIPTION
This gives a bit nicer set of information at INFO level. That doesn't
overwhelm you with the details, but can give you a general idea of what
has been done.

As part of doing manual testing with accelerated pruning, I felt it would be nice to really see what was going on. (running cs:~jameinel/peer-xplod with 24 units spread across 4 containers is a decent load test. I'd like to understand why jujud-machine-0 is at 236%CPU while mongo is only 33% CPU, but that's for another day.)

The log messages look like:
```
machine-0: 17:37:19 INFO juju.txn txns after last prune: 5, txns now: 122, pruning required: true transactions have grown significantly
machine-0: 17:37:20 INFO juju.txn txn pruning complete after 412.843118ms. txns now: 4, inspected 56 collections, 51 docs (46 cleaned)
   removed 0 stash docs and 120 txn docs
machine-0: 17:37:40 INFO juju.txn txns after last prune: 4, txns now: 122, pruning required: true transactions have grown significantly
machine-0: 17:37:40 INFO juju.txn txn pruning complete after 294.31639ms. txns now: 2, inspected 56 collections, 48 docs (47 cleaned)
   removed 0 stash docs and 121 txn docs
machine-0: 17:38:00 INFO juju.txn txns after last prune: 2, txns now: 114, pruning required: true transactions have grown significantly
machine-0: 17:38:00 INFO juju.txn txn pruning complete after 416.572073ms. txns now: 3, inspected 56 collections, 42 docs (38 cleaned)
   removed 0 stash docs and 112 txn docs
```


(Review request: http://reviews.vapour.ws/r/6517/)