### PR TITLE
track what is actually removed by Oracle.RemoveTxns()

### DIFF
--- a/oracle_test.go
+++ b/oracle_test.go
@@ -81,8 +81,9 @@ func (s *OracleSuite) TestRemovedTxns(c *gc.C) {
 		token1: true,
 		token2: true,
 	})
-	err = oracle.RemoveTxns([]bson.ObjectId{txnId1})
+	count, err := oracle.RemoveTxns([]bson.ObjectId{txnId1})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 1)
 	completed, err = oracle.CompletedTokens([]string{token1, token2})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(completed, jc.DeepEquals, map[string]bool{
@@ -111,7 +112,14 @@ func (s *OracleSuite) TestIterTxns(c *gc.C) {
 	c.Assert(oracle, gc.NotNil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(oracle.Count(), gc.Equals, 3)
-	oracle.RemoveTxns([]bson.ObjectId{txnId2})
+	count, err := oracle.RemoveTxns([]bson.ObjectId{txnId2})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 1)
+	c.Check(oracle.Count(), gc.Equals, 2)
+	// Doesn't hurt to remove one already removed
+	count, err = oracle.RemoveTxns([]bson.ObjectId{txnId2})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 0)
 	c.Check(oracle.Count(), gc.Equals, 2)
 	all := make([]bson.ObjectId, 0)
 	iter, err := oracle.IterTxns()

--- a/prune.go
+++ b/prune.go
@@ -352,7 +352,10 @@ func PruneTxns(db *mgo.Database, oracle Oracle, txns *mgo.Collection, stats *Cle
 		}
 		toRemove = toRemove[:0]
 	}
-	logger.Debugf("%d txns are still referenced and will be kept (%d we would have removed)", referencedCount, removedCount)
+	// We don't expect 'removedCount' to be nonzero because all of them
+	// should have been handled by the Clean pass.
+	logger.Debugf("%d txns are still referenced and will be kept (%d unexpected references)",
+		referencedCount, removedCount)
 
 	// Remove the no-longer-referenced transactions from the txns collection.
 	t = newSimpleTimer(logInterval)


### PR DESCRIPTION
This tracks 'references' separately from 'removals'. So we track what transactions are referenced, and we want to be safe that we aren't pruning them, but separately track whether the reference was actually in the set that we would have removed.
