### PR TITLE
Various cleanups

### DIFF
--- a/cleaner.go
+++ b/cleaner.go
@@ -355,7 +355,7 @@ func (cleaner *collectionCleaner) Cleanup() error {
 }
 
 // cleanupStash goes through the txns.stash and removes documents that are no longer needed.
-func cleanupStash(db *mgo.Database, oracle Oracle, txnsStash *mgo.Collection, stats *CleanupStats) error {
+func cleanupStash(oracle Oracle, txnsStash *mgo.Collection, stats *CleanupStats) error {
 	cleaner := NewStashCleaner(CollectionConfig{
 		Oracle:         oracle,
 		Source:         txnsStash,

--- a/cmd/txncleaner/main.go
+++ b/cmd/txncleaner/main.go
@@ -63,10 +63,7 @@ func main() {
 	txnsC := db.C(*txnsName)
 
 	startTime := time.Now()
-	stats, err := txn.CleanAndPrune(txn.CleanAndPruneArgs{
-		DB:   db,
-		Txns: txnsC,
-	})
+	stats, err := txn.CleanAndPrune(txn.CleanAndPruneArgs{Txns: txnsC})
 	if err != nil {
 		log.Fatalf("failed to clean and prune txns: %v", err)
 	}

--- a/cmd/txncleaner/main.go
+++ b/cmd/txncleaner/main.go
@@ -63,14 +63,17 @@ func main() {
 	txnsC := db.C(*txnsName)
 
 	startTime := time.Now()
-	stats, err := txn.CleanAndPrune(db, txnsC, 0)
+	stats, err := txn.CleanAndPrune(txn.CleanAndPruneArgs{
+		DB:   db,
+		Txns: txnsC,
+	})
 	if err != nil {
 		log.Fatalf("failed to clean and prune txns: %v", err)
 	}
 
 	log.Println("clean and prune complete after", time.Since(startTime))
 	log.Println(stats.DocsCleaned, "docs cleaned,", stats.TransactionsRemoved, "txns removed,",
-			    stats.StashDocumentsRemoved, "txns.stash docs removed")
+		stats.StashDocumentsRemoved, "txns.stash docs removed")
 }
 
 func dialInsecureTLS(addr *mgo.ServerAddr) (net.Conn, error) {

--- a/export_test.go
+++ b/export_test.go
@@ -22,9 +22,9 @@ var CheckMongoSupportsOut = checkMongoSupportsOut
 // NewDBOracleNoOut is only used for testing. It forces the DBOracle to not ask
 // mongo to populate the working set in the aggregation pipeline, which is our
 // compatibility code for older mongo versions.
-func NewDBOracleNoOut(db *mgo.Database, txns *mgo.Collection) (*DBOracle, func(), error) {
+func NewDBOracleNoOut(txns *mgo.Collection) (*DBOracle, func(), error) {
 	oracle := &DBOracle{
-		db:            db,
+		db:            txns.Database,
 		txns:          txns,
 		usingMongoOut: false,
 	}

--- a/oracle.go
+++ b/oracle.go
@@ -69,11 +69,11 @@ func checkMongoSupportsOut(db *mgo.Database) bool {
 // transactions.
 // The caller is responsible to call the returned cleanup() function, to ensure
 // that any resources are freed.
-func NewDBOracle(db *mgo.Database, txns *mgo.Collection) (*DBOracle, func(), error) {
+func NewDBOracle(txns *mgo.Collection) (*DBOracle, func(), error) {
 	oracle := &DBOracle{
-		db:            db,
+		db:            txns.Database,
 		txns:          txns,
-		usingMongoOut: checkMongoSupportsOut(db),
+		usingMongoOut: checkMongoSupportsOut(txns.Database),
 	}
 	cleanup, err := oracle.prepare()
 	return oracle, cleanup, err

--- a/oracle_test.go
+++ b/oracle_test.go
@@ -16,7 +16,7 @@ import (
 // OracleSuite will be run against all oracle implementations.
 type OracleSuite struct {
 	TxnSuite
-	OracleFunc func(*mgo.Database, *mgo.Collection) (jujutxn.Oracle, func(), error)
+	OracleFunc func(*mgo.Collection) (jujutxn.Oracle, func(), error)
 }
 
 func (s *OracleSuite) txnToToken(c *gc.C, id bson.ObjectId) string {
@@ -40,7 +40,7 @@ func (s *OracleSuite) TestKnownAndUnknownTxns(c *gc.C) {
 		Id:     0,
 		Update: bson.M{},
 	})
-	oracle, cleanup, err := s.OracleFunc(s.db, s.txns)
+	oracle, cleanup, err := s.OracleFunc(s.txns)
 	defer cleanup()
 	c.Assert(oracle, gc.NotNil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -69,7 +69,7 @@ func (s *OracleSuite) TestRemovedTxns(c *gc.C) {
 		Id:     1,
 		Insert: bson.M{},
 	})
-	oracle, cleanup, err := s.OracleFunc(s.db, s.txns)
+	oracle, cleanup, err := s.OracleFunc(s.txns)
 	defer cleanup()
 	c.Assert(oracle, gc.NotNil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -106,7 +106,7 @@ func (s *OracleSuite) TestIterTxns(c *gc.C) {
 		Id:     2,
 		Insert: bson.M{},
 	})
-	oracle, cleanup, err := s.OracleFunc(s.db, s.txns)
+	oracle, cleanup, err := s.OracleFunc(s.txns)
 	defer cleanup()
 	c.Assert(oracle, gc.NotNil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -125,8 +125,8 @@ func (s *OracleSuite) TestIterTxns(c *gc.C) {
 	c.Check(all, jc.DeepEquals, []bson.ObjectId{txnId1, txnId3})
 }
 
-func dbOracleFunc(db *mgo.Database, c *mgo.Collection) (jujutxn.Oracle, func(), error) {
-	return jujutxn.NewDBOracle(db, c)
+func dbOracleFunc(c *mgo.Collection) (jujutxn.Oracle, func(), error) {
+	return jujutxn.NewDBOracle(c)
 }
 
 // DBOracleSuite causes the test suite to run against the DBOracle implementation
@@ -157,8 +157,8 @@ type DBCompatOracleSuite struct {
 	OracleSuite
 }
 
-func dbNoOutOracleFunc(db *mgo.Database, c *mgo.Collection) (jujutxn.Oracle, func(), error) {
-	return jujutxn.NewDBOracleNoOut(db, c)
+func dbNoOutOracleFunc(c *mgo.Collection) (jujutxn.Oracle, func(), error) {
+	return jujutxn.NewDBOracleNoOut(c)
 }
 
 var _ = gc.Suite(&DBCompatOracleSuite{
@@ -167,7 +167,7 @@ var _ = gc.Suite(&DBCompatOracleSuite{
 	},
 })
 
-func memOracleFunc(db *mgo.Database, c *mgo.Collection) (jujutxn.Oracle, func(), error) {
+func memOracleFunc(c *mgo.Collection) (jujutxn.Oracle, func(), error) {
 	return jujutxn.NewMemOracle(c)
 }
 


### PR DESCRIPTION
Pass CleanAndPrune arguments as a struct

In preparation for adding more.

---

Avoid unnecessarily passing db around

The pruning related functions often took both a `mgo.Collection` and a
`mgo.Database`. This was unnecessary given that the database can be
retrieved from the collection. It is also safer to pass them together
given that the collection's database should never be different to the
given database.