### PR TITLE
Expose a NewestTime for PruneOptions.

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -4,6 +4,8 @@
 package txn
 
 import (
+	"time"
+
 	"gopkg.in/mgo.v2"
 )
 
@@ -22,11 +24,12 @@ var CheckMongoSupportsOut = checkMongoSupportsOut
 // NewDBOracleNoOut is only used for testing. It forces the DBOracle to not ask
 // mongo to populate the working set in the aggregation pipeline, which is our
 // compatibility code for older mongo versions.
-func NewDBOracleNoOut(txns *mgo.Collection) (*DBOracle, func(), error) {
+func NewDBOracleNoOut(txns *mgo.Collection, thresholdTime time.Time) (*DBOracle, func(), error) {
 	oracle := &DBOracle{
 		db:            txns.Database,
 		txns:          txns,
 		usingMongoOut: false,
+		thresholdTime: thresholdTime,
 	}
 	cleanup, err := oracle.prepare()
 	return oracle, cleanup, err

--- a/oracle.go
+++ b/oracle.go
@@ -71,16 +71,11 @@ func checkMongoSupportsOut(db *mgo.Database) bool {
 // timestamp. If the timestamp is empty,then only the completed status is evaluated.
 // The returned object is suitable for being passed to a $match or a Find() operation.
 func completedOldTransactionMatch(timestamp time.Time) bson.M {
-	var zeroTime = time.Time{}
-	if timestamp == zeroTime {
-		return bson.M{"s": bson.M{"$gte": taborted}}
+	match := bson.M{"s": bson.M{"$gte": taborted}}
+	if !timestamp.IsZero() {
+		match["_id"] = bson.M{"$lt": bson.NewObjectIdWithTime(timestamp)}
 	}
-	tid := bson.NewObjectIdWithTime(timestamp)
-	return bson.M{
-		"s":   bson.M{"$gte": taborted},
-		"_id": bson.M{"$lt": tid},
-	}
-
+	return match
 }
 
 // NewDBOracle uses a database collection to manage the queue of remaining

--- a/oracle_test.go
+++ b/oracle_test.go
@@ -4,6 +4,8 @@
 package txn_test
 
 import (
+	"time"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
@@ -16,7 +18,7 @@ import (
 // OracleSuite will be run against all oracle implementations.
 type OracleSuite struct {
 	TxnSuite
-	OracleFunc func(*mgo.Collection) (jujutxn.Oracle, func(), error)
+	OracleFunc func(*mgo.Collection, time.Time) (jujutxn.Oracle, func(), error)
 }
 
 func (s *OracleSuite) txnToToken(c *gc.C, id bson.ObjectId) string {
@@ -40,7 +42,7 @@ func (s *OracleSuite) TestKnownAndUnknownTxns(c *gc.C) {
 		Id:     0,
 		Update: bson.M{},
 	})
-	oracle, cleanup, err := s.OracleFunc(s.txns)
+	oracle, cleanup, err := s.OracleFunc(s.txns, time.Time{})
 	defer cleanup()
 	c.Assert(oracle, gc.NotNil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -69,7 +71,7 @@ func (s *OracleSuite) TestRemovedTxns(c *gc.C) {
 		Id:     1,
 		Insert: bson.M{},
 	})
-	oracle, cleanup, err := s.OracleFunc(s.txns)
+	oracle, cleanup, err := s.OracleFunc(s.txns, time.Time{})
 	defer cleanup()
 	c.Assert(oracle, gc.NotNil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -107,7 +109,7 @@ func (s *OracleSuite) TestIterTxns(c *gc.C) {
 		Id:     2,
 		Insert: bson.M{},
 	})
-	oracle, cleanup, err := s.OracleFunc(s.txns)
+	oracle, cleanup, err := s.OracleFunc(s.txns, time.Time{})
 	defer cleanup()
 	c.Assert(oracle, gc.NotNil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -133,8 +135,75 @@ func (s *OracleSuite) TestIterTxns(c *gc.C) {
 	c.Check(all, jc.DeepEquals, []bson.ObjectId{txnId1, txnId3})
 }
 
-func dbOracleFunc(c *mgo.Collection) (jujutxn.Oracle, func(), error) {
-	return jujutxn.NewDBOracle(c)
+func (s *OracleSuite) TestDoesntSeeNewTransactions(c *gc.C) {
+	baseTime, err := time.Parse("2006-01-02 15:04:05", "2017-01-01 12:00:00")
+	c.Assert(err, jc.ErrorIsNil)
+	txnId1 := s.runTxnWithTimestamp(c, nil, baseTime.Add(-time.Second), txn.Op{
+		C:      "coll",
+		Id:     1,
+		Insert: bson.M{},
+	})
+	s.runTxnWithTimestamp(c, nil, baseTime, txn.Op{
+		C:      "coll",
+		Id:     2,
+		Insert: bson.M{},
+	})
+	s.runTxnWithTimestamp(c, nil, baseTime.Add(time.Second), txn.Op{
+		C:      "coll",
+		Id:     3,
+		Insert: bson.M{},
+	})
+	oracle, cleanup, err := s.OracleFunc(s.txns, baseTime)
+	defer cleanup()
+	c.Assert(oracle, gc.NotNil)
+	c.Assert(err, jc.ErrorIsNil)
+	all := make([]bson.ObjectId, 0)
+	iter, err := oracle.IterTxns()
+	c.Assert(err, jc.ErrorIsNil)
+	var txnId bson.ObjectId
+	for txnId, err = iter.Next(); err == nil; txnId, err = iter.Next() {
+		all = append(all, txnId)
+	}
+	c.Assert(err, gc.Equals, jujutxn.EOF)
+	// Objects that are exactly 'baseTime' or newer are omitted
+	checkTxnIds(c, []bson.ObjectId{txnId1}, all)
+}
+
+func (s *OracleSuite) TestNoThresholdSeesAllTransactions(c *gc.C) {
+	baseTime := time.Now()
+	txnId1 := s.runTxnWithTimestamp(c, nil, baseTime.Add(-30*time.Second), txn.Op{
+		C:      "coll",
+		Id:     1,
+		Insert: bson.M{},
+	})
+	txnId2 := s.runTxnWithTimestamp(c, nil, baseTime, txn.Op{
+		C:      "coll",
+		Id:     2,
+		Insert: bson.M{},
+	})
+	txnId3 := s.runTxnWithTimestamp(c, nil, baseTime.Add(30*time.Second), txn.Op{
+		C:      "coll",
+		Id:     3,
+		Insert: bson.M{},
+	})
+	oracle, cleanup, err := s.OracleFunc(s.txns, time.Time{})
+	defer cleanup()
+	c.Assert(oracle, gc.NotNil)
+	c.Assert(err, jc.ErrorIsNil)
+	all := make([]bson.ObjectId, 0)
+	iter, err := oracle.IterTxns()
+	c.Assert(err, jc.ErrorIsNil)
+	var txnId bson.ObjectId
+	for txnId, err = iter.Next(); err == nil; txnId, err = iter.Next() {
+		all = append(all, txnId)
+	}
+	c.Assert(err, gc.Equals, jujutxn.EOF)
+	// Objects that are exactly 'baseTime' or newer are omitted
+	checkTxnIds(c, []bson.ObjectId{txnId1, txnId2, txnId3}, all)
+}
+
+func dbOracleFunc(c *mgo.Collection, thresholdTime time.Time) (jujutxn.Oracle, func(), error) {
+	return jujutxn.NewDBOracle(c, thresholdTime)
 }
 
 // DBOracleSuite causes the test suite to run against the DBOracle implementation
@@ -165,8 +234,8 @@ type DBCompatOracleSuite struct {
 	OracleSuite
 }
 
-func dbNoOutOracleFunc(c *mgo.Collection) (jujutxn.Oracle, func(), error) {
-	return jujutxn.NewDBOracleNoOut(c)
+func dbNoOutOracleFunc(c *mgo.Collection, thresholdTime time.Time) (jujutxn.Oracle, func(), error) {
+	return jujutxn.NewDBOracleNoOut(c, thresholdTime)
 }
 
 var _ = gc.Suite(&DBCompatOracleSuite{
@@ -175,8 +244,8 @@ var _ = gc.Suite(&DBCompatOracleSuite{
 	},
 })
 
-func memOracleFunc(c *mgo.Collection) (jujutxn.Oracle, func(), error) {
-	return jujutxn.NewMemOracle(c)
+func memOracleFunc(c *mgo.Collection, thresholdTime time.Time) (jujutxn.Oracle, func(), error) {
+	return jujutxn.NewMemOracle(c, thresholdTime)
 }
 
 type MemOracleSuite struct {

--- a/prune.go
+++ b/prune.go
@@ -134,9 +134,9 @@ func maybePrune(db *mgo.Database, txnsName string, pruneOpts PruneOptions) error
 	}
 
 	stats, err := CleanAndPrune(CleanAndPruneArgs{
-		Txns:       txns,
-		TxnsCount:  txnsCount,
-		NewestTime: pruneOpts.NewestTime,
+		Txns:      txns,
+		TxnsCount: txnsCount,
+		MaxTime:   pruneOpts.MaxTime,
 	})
 	completed := time.Now()
 
@@ -171,10 +171,10 @@ type CleanAndPruneArgs struct {
 	// It is optional, as we will call Txns.Count() if it is not supplied.
 	TxnsCount int
 
-	// NewestTime is a timestamp that provides a threshold of transactions
+	// MaxTime is a timestamp that provides a threshold of transactions
 	// that we will actually prune. Only transactions that were created
 	// before this threshold will be pruned.
-	NewestTime time.Time
+	MaxTime time.Time
 }
 
 func (args *CleanAndPruneArgs) validate() error {
@@ -248,9 +248,9 @@ func CleanAndPrune(args CleanAndPruneArgs) (CleanupStats, error) {
 func getOracle(args CleanAndPruneArgs, maxMemoryTxns int) (Oracle, func(), error) {
 	// If we don't have very many transactions, just use the in-memory version
 	if args.TxnsCount < maxMemoryTxns {
-		return NewMemOracle(args.Txns, args.NewestTime)
+		return NewMemOracle(args.Txns, args.MaxTime)
 	}
-	return NewDBOracle(args.Txns, args.NewestTime)
+	return NewDBOracle(args.Txns, args.MaxTime)
 }
 
 // getPruneLastTxnsCount will return how many documents were in 'txns' the

--- a/prune_test.go
+++ b/prune_test.go
@@ -36,7 +36,7 @@ func (s *PruneSuite) maybePruneWithTimestamp(c *gc.C, pruneFactor float32, times
 		PruneFactor:        pruneFactor,
 		MinNewTransactions: 1,
 		MaxNewTransactions: 1000,
-		NewestTime:         timestamp,
+		MaxTime:            timestamp,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/prune_test.go
+++ b/prune_test.go
@@ -22,6 +22,11 @@ type PruneSuite struct {
 var _ = gc.Suite(&PruneSuite{})
 
 func (s *PruneSuite) maybePrune(c *gc.C, pruneFactor float32) {
+	// A 'zero' timestamp means to ignore the time threshold
+	s.maybePruneWithTimestamp(c, pruneFactor, time.Time{})
+}
+
+func (s *PruneSuite) maybePruneWithTimestamp(c *gc.C, pruneFactor float32, timestamp time.Time) {
 	r := jujutxn.NewRunner(jujutxn.RunnerParams{
 		Database:                  s.db,
 		TransactionCollectionName: s.txns.Name,
@@ -31,6 +36,7 @@ func (s *PruneSuite) maybePrune(c *gc.C, pruneFactor float32) {
 		PruneFactor:        pruneFactor,
 		MinNewTransactions: 1,
 		MaxNewTransactions: 1000,
+		NewestTime:         timestamp,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -359,6 +365,28 @@ func (s *PruneSuite) TestManyTxnRemovals(c *gc.C) {
 	s.maybePrune(c, 1)
 	s.assertTxns(c)
 	s.assertDocQueue(c, "coll", 0)
+}
+
+func (s *PruneSuite) TestIgnoresNewTxns(c *gc.C) {
+	baseTime, err := time.Parse("2006-01-02 15:04:05", "2017-01-01 12:00:00")
+	c.Assert(err, jc.ErrorIsNil)
+	s.runTxnWithTimestamp(c, nil, baseTime.Add(-30*time.Second), txn.Op{
+		C:      "coll",
+		Id:     0,
+		Insert: bson.M{},
+	})
+	txnId2 := s.runTxnWithTimestamp(c, nil, baseTime, txn.Op{
+		C:      "coll",
+		Id:     0,
+		Update: bson.M{},
+	})
+	txnId3 := s.runTxnWithTimestamp(c, nil, baseTime.Add(30*time.Second), txn.Op{
+		C:      "col",
+		Id:     0,
+		Remove: true,
+	})
+	s.maybePruneWithTimestamp(c, 1, baseTime)
+	s.assertTxns(c, txnId2, txnId3)
 }
 
 func (s *PruneSuite) TestFirstRun(c *gc.C) {

--- a/txn.go
+++ b/txn.go
@@ -15,6 +15,7 @@ package txn
 import (
 	stderrors "errors"
 	"strings"
+	"time"
 
 	"github.com/juju/loggo"
 	"gopkg.in/mgo.v2"
@@ -56,15 +57,24 @@ type TransactionSource func(attempt int) ([]txn.Op, error)
 
 // PruneOptions controls when we will trigger a database prune.
 type PruneOptions struct {
+
 	// PruneFactor will trigger a prune when the current count of
 	// transactions in the database is greater than old*PruneFactor
 	PruneFactor float32
+
 	// MinNewTransactions will skip a prune even if pruneFactor is true
 	// if there are less than MinNewTransactions that might be cleaned up.
 	MinNewTransactions int
+
 	// MaxNewTransactions will force a prune if it sees more than
 	// MaxNewTransactions since the last run.
 	MaxNewTransactions int
+
+	// NewestTime sets a threshold for 'completed' transactions. Transactions
+	// will be considered completed only if they are both older than
+	// NewestTime and have a status of Completed or Aborted. Passing the
+	// zero Time will cause us to only filter on the Status field.
+	NewestTime time.Time
 }
 
 // Runner instances applies operations to collections in a database.

--- a/txn.go
+++ b/txn.go
@@ -70,11 +70,11 @@ type PruneOptions struct {
 	// MaxNewTransactions since the last run.
 	MaxNewTransactions int
 
-	// NewestTime sets a threshold for 'completed' transactions. Transactions
+	// MaxTime sets a threshold for 'completed' transactions. Transactions
 	// will be considered completed only if they are both older than
-	// NewestTime and have a status of Completed or Aborted. Passing the
+	// MaxTime and have a status of Completed or Aborted. Passing the
 	// zero Time will cause us to only filter on the Status field.
-	NewestTime time.Time
+	MaxTime time.Time
 }
 
 // Runner instances applies operations to collections in a database.


### PR DESCRIPTION
This allows us to set a time threshold for what transactions
we will treat as completed/aborted. Callers can then set a value
and we will not prune transactions that are newer than that time.