### PR TITLE
Handle Bulk.Run() result being nil

### DIFF
--- a/prune.go
+++ b/prune.go
@@ -585,7 +585,9 @@ func (r *bulkRemover) Flush() error {
 	case nil, mgo.ErrNotFound:
 		// It's OK for txns to no longer exist. Another process
 		// may have concurrently pruned them.
-		r.removed += result.Matched
+		if result != nil {
+			r.removed += result.Matched
+		}
 		r.newChunk()
 		return nil
 	default:


### PR DESCRIPTION
If err is ErrNotFound then result will be nil, triggering a panic.

Fixes https://bugs.launchpad.net/juju/+bug/1697795