### PR TITLE
Expose the batch size and number of batches.

### DIFF
--- a/prune.go
+++ b/prune.go
@@ -81,6 +81,9 @@ func validatePruneOptions(pruneOptions *PruneOptions) {
 	if pruneOptions.MaxNewTransactions == 0 {
 		pruneOptions.MaxNewTransactions = defaultMaxNewTransactions
 	}
+	if pruneOptions.MaxBatches <= 0 {
+		pruneOptions.MaxBatches = 1
+	}
 }
 
 func shouldPrune(oldCount, newCount int, pruneOptions PruneOptions) (bool, string) {
@@ -103,6 +106,7 @@ func shouldPrune(oldCount, newCount int, pruneOptions PruneOptions) (bool, strin
 
 func maybePrune(db *mgo.Database, txnsName string, pruneOpts PruneOptions) error {
 	validatePruneOptions(&pruneOpts)
+	logger.Debugf("validated pruneOpts: %#v", pruneOpts)
 	txnsPrune := db.C(txnsPruneC(txnsName))
 	txns := db.C(txnsName)
 	txnsStashName := txnsName + ".stash"
@@ -133,28 +137,50 @@ func maybePrune(db *mgo.Database, txnsName string, pruneOpts PruneOptions) error
 		return fmt.Errorf("failed to retrieve starting %q count: %v", txnsStashName, err)
 	}
 
-	stats, err := CleanAndPrune(CleanAndPruneArgs{
-		Txns:      txns,
-		TxnsCount: txnsCount,
-		MaxTime:   pruneOpts.MaxTime,
-	})
-	completed := time.Now()
+	var stats CleanupStats
+	var txnsCountAfter int
+	var stashDocsAfter int
+	txnsCountBefore := txnsCount
+	batchCount := 0
+	for ; batchCount < pruneOpts.MaxBatches; batchCount++ {
+		// Note: jam 2018-08-16 If there are lots of txns that cannot be
+		// pruned, then batch size will mean we end up looking at the same
+		// transactions repeatedly. However, as long as the queries prefer
+		// old transactions, the chances that those are stale is low.
+		batchStarted := time.Now()
+		batchStats, err := CleanAndPrune(CleanAndPruneArgs{
+			Txns:                     txns,
+			TxnsCount:                txnsCount,
+			MaxTime:                  pruneOpts.MaxTime,
+			MaxTransactionsToProcess: pruneOpts.MaxBatchTransactions,
+		})
 
-	txnsCountAfter, err := txns.Count()
-	if err != nil {
-		return fmt.Errorf("failed to retrieve final txns count: %v", err)
-	}
-	stashDocsAfter, err := txnsStash.Count()
-	if err != nil {
-		return fmt.Errorf("failed to retrieve final %q count: %v", txnsStashName, err)
+		txnsCountAfter, err = txns.Count()
+		if err != nil {
+			return fmt.Errorf("failed to retrieve final txns count: %v", err)
+		}
+		stashDocsAfter, err = txnsStash.Count()
+		if err != nil {
+			return fmt.Errorf("failed to retrieve final %q count: %v", txnsStashName, err)
+		}
+		stats.CollectionsInspected += batchStats.CollectionsInspected
+		stats.DocsInspected += batchStats.DocsInspected
+		stats.DocsCleaned += batchStats.DocsCleaned
+		stats.StashDocumentsRemoved += batchStats.StashDocumentsRemoved
+		stats.TransactionsRemoved += batchStats.TransactionsRemoved
+		if !batchStats.ShouldRetry {
+			break
+		}
+		logger.Infof("txn batch pruned in %v. txns now: %d, inspected %d collections, %d docs (%d cleaned)\n   removed %d stash docs and %d txn docs",
+			time.Since(batchStarted), txnsCountAfter, stats.CollectionsInspected, stats.DocsInspected, stats.DocsCleaned, stats.StashDocumentsRemoved, stats.TransactionsRemoved)
+		txnsCount = txnsCountAfter
 	}
 	elapsed := time.Since(started)
-	logger.Infof("txn pruning complete after %v. txns now: %d, inspected %d collections, %d docs (%d cleaned)\n   removed %d stash docs and %d txn docs",
-		elapsed, txnsCountAfter, stats.CollectionsInspected, stats.DocsInspected, stats.DocsCleaned, stats.StashDocumentsRemoved, stats.TransactionsRemoved)
-	return writePruneTxnsCount(txnsPrune, started, completed, txnsCount, txnsCountAfter,
+	logger.Infof("txn pruning complete after %v in %d batches. txns now: %d, inspected %d collections, %d docs (%d cleaned)\n   removed %d stash docs and %d txn docs",
+		elapsed, batchCount, txnsCountAfter, stats.CollectionsInspected, stats.DocsInspected, stats.DocsCleaned, stats.StashDocumentsRemoved, stats.TransactionsRemoved)
+	completed := time.Now()
+	return writePruneTxnsCount(txnsPrune, started, completed, txnsCountBefore, txnsCountAfter,
 		stashDocsBefore, stashDocsAfter)
-
-	return nil
 }
 
 // CleanAndPruneArgs specifies the parameters required by CleanAndPrune.
@@ -238,7 +264,7 @@ func CleanAndPrune(args CleanAndPruneArgs) (CleanupStats, error) {
 	txnsStashName := args.Txns.Name + ".stash"
 	txnsStash := db.C(txnsStashName)
 
-	if oracle.Count() > int(float64(args.MaxTransactionsToProcess)*0.9) {
+	if args.MaxTransactionsToProcess > 0 && oracle.Count() > int(float64(args.MaxTransactionsToProcess)*0.9) {
 		stats.ShouldRetry = true
 	}
 	if err := cleanupStash(oracle, txnsStash, &stats); err != nil { // XXX

--- a/prune_test.go
+++ b/prune_test.go
@@ -482,6 +482,37 @@ func (s *PruneSuite) TestPruningStatsBrokenLastPointer(c *gc.C) {
 		[]jc.SimpleMessage{{loggo.WARNING, `pruning stats pointer was broken .+`}})
 }
 
+func (s *PruneSuite) TestMaxBatchesAndMaxBatchTransactions(c *gc.C) {
+	const numTransactions = 10
+
+	for id := 0; id < numTransactions; id++ {
+		s.runTxn(c, txn.Op{
+			C:      "coll",
+			Id:     id,
+			Insert: bson.M{},
+		})
+
+	}
+	s.assertCollCount(c, "txns", 10)
+	// Now do a prune, but pass in limits to how much we will prune per pass, and how many passes we will do
+	r := jujutxn.NewRunner(jujutxn.RunnerParams{
+		Database:                  s.db,
+		TransactionCollectionName: s.txns.Name,
+		ChangeLogName:             s.txns.Name + ".log",
+		Clock:                     testing.NewClock(time.Now()),
+	})
+	err := r.MaybePruneTransactions(jujutxn.PruneOptions{
+		PruneFactor:          2.0,
+		MinNewTransactions:   1,
+		MaxNewTransactions:   1000,
+		MaxBatches:           4,
+		MaxBatchTransactions: 2,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	// we should have pruned 2 txns in each batch, 4 batches, leaves us with 8 pruned, and 2 remaining.
+	s.assertCollCount(c, "txns", 2)
+}
+
 func (s *PruneSuite) makeTxnsForNewDoc(c *gc.C, count int) {
 	id := bson.NewObjectId()
 	s.runTxn(c, txn.Op{

--- a/txn.go
+++ b/txn.go
@@ -76,6 +76,17 @@ type PruneOptions struct {
 	// MaxTime and have a status of Completed or Aborted. Passing the
 	// zero Time will cause us to only filter on the Status field.
 	MaxTime time.Time
+
+	// MaxBatchTransactions is the most transactions that we will prune in a single pass.
+	// It is possible to pass 0 to prune all transactions in a pass. Note
+	// that MaybePruneTransactions will always process all transactions, it
+	// is just whether we do so in multiple passes, or whether it is done
+	// all at once.
+	MaxBatchTransactions uint64
+
+	// MaxBatches is the maximum number of passes we will attempt. 0 or
+	// negative values are treated as do a single pass.
+	MaxBatches int
 }
 
 // Runner instances applies operations to collections in a database.


### PR DESCRIPTION
We go ahead and do the loop inside MaybePruneTransactions, rather than
exposing it entirely. Otherwise we would have needed to expose the
CleanupStats. This should allow us to update github.com/juju/juju with
the configuration knobs as to how we want to batch our transactions
(default 1M, 100 max batches).