### PR TITLE
Pass the transaction attempt

### DIFF
--- a/txn.go
+++ b/txn.go
@@ -103,7 +103,7 @@ type PruneOptions struct {
 // Runner instances applies operations to collections in a database.
 type Runner interface {
 	// RunTransaction applies the specified transaction operations to a database.
-	RunTransaction(ops []txn.Op) error
+	RunTransaction(ops []txn.Op, attempt int) error
 
 	// Run calls the nominated function to get the transaction operations to apply to a database.
 	// If there is a failure due to a txn.ErrAborted error, the attempt is retried up to nrRetries times.
@@ -158,6 +158,9 @@ type ObservedTransaction struct {
 	Error error
 	// Duration is length of time it took to run the operation
 	Duration time.Duration
+	// Attempt is the number of attempts it took for the transaction to be
+	// applied
+	Attempt int
 }
 
 // RunnerParams are used to construct a new transaction runner.
@@ -238,7 +241,7 @@ func (tr *transactionRunner) Run(transactions TransactionSource) error {
 			// Treat this the same as ErrNoOperations but don't suppress other errors.
 			return nil
 		}
-		if err := tr.RunTransaction(ops); err == nil {
+		if err := tr.RunTransaction(ops, i); err == nil {
 			return nil
 		} else if err != txn.ErrAborted {
 			// Mongo very occasionally returns an intermittent
@@ -254,7 +257,7 @@ func (tr *transactionRunner) Run(transactions TransactionSource) error {
 }
 
 // RunTransaction is defined on Runner.
-func (tr *transactionRunner) RunTransaction(ops []txn.Op) error {
+func (tr *transactionRunner) RunTransaction(ops []txn.Op, attempt int) error {
 	testHooks := <-tr.testHooks
 	tr.testHooks <- nil
 	if len(testHooks) > 0 {
@@ -287,6 +290,7 @@ func (tr *transactionRunner) RunTransaction(ops []txn.Op) error {
 			Ops:      ops,
 			Error:    err,
 			Duration: delta,
+			Attempt:  attempt,
 		})
 	}
 	return err

--- a/txn.go
+++ b/txn.go
@@ -158,8 +158,7 @@ type ObservedTransaction struct {
 	Error error
 	// Duration is length of time it took to run the operation
 	Duration time.Duration
-	// Attempt is the number of attempts it took for the transaction to be
-	// applied
+	// Attempt is the current attempt to apply the operation.
 	Attempt int
 }
 

--- a/txn_test.go
+++ b/txn_test.go
@@ -65,7 +65,7 @@ func (s *txnSuite) TestRunTransaction(c *gc.C) {
 		Assert: txn.DocMissing,
 		Insert: doc,
 	}}
-	err := s.txnRunner.RunTransaction(ops)
+	err := s.txnRunner.RunTransaction(ops, 0)
 	c.Assert(err, gc.IsNil)
 	var found simpleDoc
 	err = s.collection.FindId("1").One(&found)
@@ -102,7 +102,7 @@ func (s *txnSuite) setDocName(c *gc.C, id, name string) {
 		Assert: txn.DocExists,
 		Update: bson.D{{"$set", bson.D{{"name", name}}}},
 	}}
-	err := s.txnRunner.RunTransaction(ops)
+	err := s.txnRunner.RunTransaction(ops, 0)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -114,7 +114,7 @@ func (s *txnSuite) insertDoc(c *gc.C, id, name string) {
 		Assert: txn.DocMissing,
 		Insert: doc,
 	}}
-	err := s.txnRunner.RunTransaction(ops)
+	err := s.txnRunner.RunTransaction(ops, 0)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -351,9 +351,11 @@ func (s *txnSuite) TestRunTransactionObserver(c *gc.C) {
 	c.Check(calls[0].Ops, gc.DeepEquals, ops)
 	c.Check(calls[0].Error, gc.Equals, txn.ErrAborted)
 	c.Check(calls[0].Duration, gc.Equals, time.Second)
+	c.Check(calls[0].Attempt, gc.Equals, 0)
 	c.Check(calls[1].Ops, gc.DeepEquals, ops)
 	c.Check(calls[1].Error, gc.IsNil)
 	c.Check(calls[1].Duration, gc.Equals, 100*time.Millisecond)
+	c.Check(calls[1].Attempt, gc.Equals, 1)
 }
 
 type fakeRunner struct {


### PR DESCRIPTION
The following changes pass the transaction attempt through to the
RunTransaction, which can then pass it on to the observer. This
should hopefully allow us to then workout how many attempts and the
duration of the transaction operation.

@jameinel in regards to "RunTransactionObserver doesn't currently take the time for the transaction into account", isn't the `Duration` on `ObservedTransaction` doing that?