### PR TITLE
Add help text to explain why hooks do not run

### DIFF
--- a/testing/testing.go
+++ b/testing/testing.go
@@ -72,6 +72,10 @@ func SetTestHooks(c *gc.C, runner txn.Runner, hooks ...txn.TestHook) Transaction
 	return func() {
 		remaining := <-transactionHooks
 		transactionHooks <- nil
+		// At least one hook has not run. Some common causes:
+		// - forgetting to prefix the call to Check() with defer
+		// - checks in the build function failing, so the slice of txn.Ops never gets run
+		// - miscalculating the number of hooks and/or attempts
 		c.Assert(remaining, gc.HasLen, 0)
 	}
 }


### PR DESCRIPTION
This PR provides some more context to unassuming new developers who are learning about BeforeHooks/AfterHooks.

Using check's comment feature, this message is displayed:

```plain
// At least one hook has not run. Some common causes:
    // - forgetting to prefix the call to Check() with defer
    // - checks in the build function failing, so the slice of txn.Ops never gets run
    // - miscalculating the number of hooks and/or attempts
    c.Assert(remaining, gc.HasLen, 0)
	... obtained []txn.TestHook = []txn.TestHook{txn.TestHook{Before:(func())(0x2f78a10), After:(func())(0x2f78bb0)}, txn.TestHook{Before:(func())(0x2f78a10), After:(func())(0x2f78bb0)}, txn.TestHook{Before:(func())(0x2f78a10), After:(func())(0x2f78bb0)}}
... n int = 0
```

Hopefully this is more useful to newcomers than the bald Assert failure:

	c.Assert(remaining, gc.HasLen, 0)
	... obtained []txn.TestHook = []txn.TestHook{txn.TestHook{Before:(func())(0x2f78a10), After:(func())(0x2f78bb0)}, txn.TestHook{Before:(func())(0x2f78a10), After:(func())(0x2f78bb0)}, txn.TestHook{Before:(func())(0x2f78a10), After:(func())(0x2f78bb0)}}
	... n int = 0
