### PR TITLE
Properly handle when RemoveAll returns an error.

### DIFF
--- a/incrementalprune.go
+++ b/incrementalprune.go
@@ -719,16 +719,17 @@ func (p *IncrementalPruner) removeTxns(txnsToDelete []bson.ObjectId, txns *mgo.C
 		results, err := txns.RemoveAll(bson.M{
 			"_id": bson.M{"$in": txnsToDelete},
 		})
-		logger.Tracef("removing %d txns removed %d", len(txnsToDelete), results.Removed)
-		p.stats.TxnsRemoved += int64(results.Removed)
-		p.stats.TxnRemoveTime += time.Since(tStart)
-		if p.ProgressChan != nil {
-			p.ProgressChan <- ProgressMessage{
-				TxnsRemoved: results.Removed,
-			}
-		}
 		if err != nil {
 			errorCh <- errors.Trace(err)
+		} else {
+			logger.Tracef("removing %d txns removed %d", len(txnsToDelete), results.Removed)
+			p.stats.TxnsRemoved += int64(results.Removed)
+			p.stats.TxnRemoveTime += time.Since(tStart)
+			if p.ProgressChan != nil {
+				p.ProgressChan <- ProgressMessage{
+					TxnsRemoved: results.Removed,
+				}
+			}
 		}
 		session.Close()
 		wg.Done()


### PR DESCRIPTION
If txns.RemoveAll returns an error, it also returns a nil result
pointer. The old code would propagate the error, but not until after it
accessed attributes of the nil result.

Addresses https://bugs.launchpad.net/bugs/1903202

It doesn't fix any underlying error, but it avoids having an error turn into a panic().

I didn't see a clean way to inject errors into the system, though I'm still looking. I mostly wanted to propose a possible fix so we can find progress.