### PR TITLE
Add started and asserted hooks for sstxn testing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+.vscode/


### PR DESCRIPTION
Adds two extra hooks for sstxn manipulation for testing.
- Started hook is called after StartTransaction on the mgo.Session.
- Asserted hook is called after transaction assertions have been made.